### PR TITLE
Add new Spring to Quarkus migration skill

### DIFF
--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -6,8 +6,7 @@ description: Migrates Spring Boot applications to Quarkus using a modular, gate-
   "quarkus migration", "replace spring", or asks about migrating "pom.xml", "build.gradle", "Spring MVC", "Spring Data JPA", "Thymeleaf", "@SpringBootApplication".
 license: Apache-2.0
 metadata:
-  author: Quarkus Team - https://github.com/quarkusio/quarkus
-  version: "0.1.0"
+  author: Quarkus Community - https://github.com/quarkusio/quarkus
 ---
 
 # Spring Boot to Quarkus Migration
@@ -21,7 +20,7 @@ Modular, gate-driven migration of Spring Boot applications to Quarkus.
     - Spring-specific patterns without a clear Quarkus equivalent
     - Configuration or wiring code whose purpose is unclear
       If you must remove code (e.g., a Spring-only base class), document what was removed and why in a `// REMOVED:` comment at the same location.
-- **Don't break the build.** Run the compile command after each phase (`mvn clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle). Never move to the next phase with a broken build.
+- **Don't break the build.** Run the compile command after each phase (`./mvnw clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle). Never move to the next phase with a broken build.
 - **Document every decision.** When choosing between migration approaches, explain the trade-off to the user.
 - **No silent changes.** Every file modification must be intentional and traceable. If a check fails after a phase, diagnose and fix — don't skip the check or delete the failing code.
 
@@ -91,7 +90,7 @@ FOR module IN [build, code, frontend, testing, cleanup]:
      IF gate == SKIP   → log "Module {name}: SKIPPED — {reason}", mark checkbox, continue
   3. LOAD — read the module file and relevant reference files
   4. EXECUTE — follow the module instructions, adapting to the chosen strategy
-  5. COMPILE — run the project's compile command (`mvn clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle)
+  5. COMPILE — run the project's compile command (`./mvnw clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle)
      Fails → diagnose and fix before proceeding
   6. LOG — mark checkbox as done
 ```
@@ -112,11 +111,11 @@ Run each check in order. A check fails = stop and fix before continuing.
 
 | # | Check | Command (Maven / Gradle) | Pass criteria |
 |---|-------|---------|---------------|
-| 1 | **Builds** | `mvn clean package -DskipTests` / `./gradlew clean build -x test` | Exit code 0, no compilation errors |
+| 1 | **Builds** | `./mvnw clean package -DskipTests` / `./gradlew clean build -x test` | Exit code 0, no compilation errors |
 | 2 | **No Spring deps** | Search build file for `org.springframework` | Zero Spring deps (except Spring compat extensions if using that strategy) |
 | 3 | **Has Quarkus** | Search build file for `io.quarkus` | Quarkus BOM and at least one extension present |
-| 4 | **Tests pass** | `mvn test` / `./gradlew test` | All tests pass using `@QuarkusTest` |
-| 5 | **Starts up** | `mvn quarkus:dev` / `./gradlew quarkusDev` | App starts, `curl http://localhost:8080/q/health` returns UP |
+| 4 | **Tests pass** | `./mvnw test` / `./gradlew test` | All tests pass using `@QuarkusTest` |
+| 5 | **Starts up** | `./mvnw quarkus:dev` / `./gradlew quarkusDev` | App starts, `curl http://localhost:8080/q/health` returns UP |
 | 6 | **No leftover templates** | Search for Thymeleaf/JSP references | None remaining (unless intentionally kept) |
 
 ## Step 5: Migration Review (Self-Reflection)

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -3,7 +3,7 @@ name: migrate-spring-to-quarkus
 description: Migrates Spring Boot applications to Quarkus using a modular, gate-driven approach. 
   Supports Spring compatibility extensions and native Quarkus migration paths. 
   Use when the user wants to migrate, convert, or port a Spring Boot app to Quarkus, mentions "spring to quarkus", 
-  "quarkus migration", "replace spring", or asks about migrating "pom.xml", "Spring MVC", "Spring Data JPA", "Thymeleaf", "@SpringBootApplication".
+  "quarkus migration", "replace spring", or asks about migrating "pom.xml", "build.gradle", "Spring MVC", "Spring Data JPA", "Thymeleaf", "@SpringBootApplication".
 license: Apache-2.0
 metadata:
   author: Quarkus Team - https://github.com/quarkusio/quarkus
@@ -21,7 +21,7 @@ Modular, gate-driven migration of Spring Boot applications to Quarkus.
     - Spring-specific patterns without a clear Quarkus equivalent
     - Configuration or wiring code whose purpose is unclear
       If you must remove code (e.g., a Spring-only base class), document what was removed and why in a `// REMOVED:` comment at the same location.
-- **Don't break the build.** Run `mvn clean compile -DskipTests` after each phase. Never move to the next phase with a broken build.
+- **Don't break the build.** Run the compile command after each phase (`mvn clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle). Never move to the next phase with a broken build.
 - **Document every decision.** When choosing between migration approaches, explain the trade-off to the user.
 - **No silent changes.** Every file modification must be intentional and traceable. If a check fails after a phase, diagnose and fix — don't skip the check or delete the failing code.
 
@@ -40,7 +40,7 @@ Load the relevant reference file when working on a module:
 
 Scan the application to understand what needs to migrate:
 
-- **Build system**: Read `pom.xml` — Spring Boot version, starters, plugins
+- **Build system**: Read the build file (`pom.xml` for Maven, `build.gradle` or `build.gradle.kts` for Gradle) — Spring Boot version, starters, plugins
 - **Java code**: Search for Spring annotations (DI, REST, Data, Security, Scheduling)
 - **Configuration**: Read `application.properties`/`application.yml`, check for profiles
 - **UI / View layer**: Check for Thymeleaf/JSP templates, static resources, Model+View patterns
@@ -73,7 +73,7 @@ Inspect the project to determine the gate result — do not rely on blind grep c
 | Module                          | Gate Check                                                                                                                | Gate Result                                                                              |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
 | [jdk](modules/jdk.md)           | JDK 21+ required                                   | **ALWAYS** -- stop migration if < 21 |
-| [build](modules/build.md)       | Spring Boot parent, starters, or spring-boot-maven-plugin in pom.xml                                                      | **PASS** if Spring Boot build markers found; **SKIP** otherwise                          |
+| [build](modules/build.md)       | Spring Boot parent/starters/`spring-boot-maven-plugin` in `pom.xml`, or Spring Boot/`io.spring.dependency-management` plugins in `build.gradle(.kts)` | **PASS** if Spring Boot build markers found; **SKIP** otherwise                          |
 | [code](modules/code.md)         | Spring annotations in Java sources (`@Component`, `@Service`, `@Controller`, `@Repository`, `@Entity`, `@Autowired`, etc.) | **PASS** if Spring annotations found; **SKIP** otherwise                                 |
 | [frontend](modules/frontend.md) | Thymeleaf/JSP templates in `templates/` or static resources in `static/`                                                  | **PASS** if view layer found; **SKIP** otherwise                                         |
 | [testing](modules/testing.md)   | Spring test annotations in test sources (`@SpringBootTest`, `@WebMvcTest`, `@MockBean`)                                   | **PASS** if Spring tests found; **SKIP** otherwise                                       |
@@ -91,7 +91,7 @@ FOR module IN [build, code, frontend, testing, cleanup]:
      IF gate == SKIP   → log "Module {name}: SKIPPED — {reason}", mark checkbox, continue
   3. LOAD — read the module file and relevant reference files
   4. EXECUTE — follow the module instructions, adapting to the chosen strategy
-  5. COMPILE — run `mvn clean compile -DskipTests`
+  5. COMPILE — run the project's compile command (`mvn clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle)
      Fails → diagnose and fix before proceeding
   6. LOG — mark checkbox as done
 ```
@@ -110,13 +110,13 @@ The module will use the current project state and the chosen strategy (if alread
 
 Run each check in order. A check fails = stop and fix before continuing.
 
-| # | Check | Command | Pass criteria |
+| # | Check | Command (Maven / Gradle) | Pass criteria |
 |---|-------|---------|---------------|
-| 1 | **Builds** | `mvn clean package -DskipTests` | Exit code 0, no compilation errors |
-| 2 | **No Spring deps** | Search `pom.xml` for `org.springframework` | Zero Spring deps (except Spring compat extensions if using that strategy) |
-| 3 | **Has Quarkus** | Search `pom.xml` for `io.quarkus` | Quarkus BOM and at least one extension present |
-| 4 | **Tests pass** | `mvn test` | All tests pass using `@QuarkusTest` |
-| 5 | **Starts up** | `mvn quarkus:dev` | App starts, `curl http://localhost:8080/q/health` returns UP |
+| 1 | **Builds** | `mvn clean package -DskipTests` / `./gradlew clean build -x test` | Exit code 0, no compilation errors |
+| 2 | **No Spring deps** | Search build file for `org.springframework` | Zero Spring deps (except Spring compat extensions if using that strategy) |
+| 3 | **Has Quarkus** | Search build file for `io.quarkus` | Quarkus BOM and at least one extension present |
+| 4 | **Tests pass** | `mvn test` / `./gradlew test` | All tests pass using `@QuarkusTest` |
+| 5 | **Starts up** | `mvn quarkus:dev` / `./gradlew quarkusDev` | App starts, `curl http://localhost:8080/q/health` returns UP |
 | 6 | **No leftover templates** | Search for Thymeleaf/JSP references | None remaining (unless intentionally kept) |
 
 ## Step 5: Migration Review (Self-Reflection)
@@ -149,7 +149,7 @@ Present the review as a structured report:
 ### Changes by Module
 | Module | Files changed | Key changes |
 |--------|--------------|-------------|
-| build | pom.xml, application.properties | ... |
+| build | pom.xml or build.gradle(.kts), application.properties | ... |
 | code | ... | ... |
 | frontend | ... | ... |
 | testing | ... | ... |

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: migrate-spring-to-quarkus
+description: Migrates Spring Boot applications to Quarkus using a modular, gate-driven approach. 
+  Supports Spring compatibility extensions and native Quarkus migration paths. 
+  Use when the user wants to migrate, convert, or port a Spring Boot app to Quarkus, mentions "spring to quarkus", 
+  "quarkus migration", "replace spring", or asks about migrating "pom.xml", "Spring MVC", "Spring Data JPA", "Thymeleaf", "@SpringBootApplication".
+license: Apache-2.0
+metadata:
+  author: Quarkus Team - https://github.com/quarkusio/quarkus
+  version: "0.1.0"
+---
+
+# Spring Boot to Quarkus Migration
+
+Modular, gate-driven migration of Spring Boot applications to Quarkus.
+
+## Critical Rules
+
+- **Never delete code you cannot migrate.** If you cannot fully migrate a piece of code, leave the original in place with a `// TODO: Migration required — <reason>` comment explaining what needs to change and why. This applies to:
+    - Methods, classes, or annotations you don't know how to convert
+    - Spring-specific patterns without a clear Quarkus equivalent
+    - Configuration or wiring code whose purpose is unclear
+      If you must remove code (e.g., a Spring-only base class), document what was removed and why in a `// REMOVED:` comment at the same location.
+- **Don't break the build.** Run `mvn clean compile -DskipTests` after each phase. Never move to the next phase with a broken build.
+- **Document every decision.** When choosing between migration approaches, explain the trade-off to the user.
+- **No silent changes.** Every file modification must be intentional and traceable. If a check fails after a phase, diagnose and fix — don't skip the check or delete the failing code.
+
+## Reference Files
+
+Load the relevant reference file when working on a module:
+
+| Reference | Use during |
+|---|---|
+| [references/dependency-map.md](references/dependency-map.md) | Build module: dependency and plugin mapping |
+| [references/annotation-map.md](references/annotation-map.md) | Code module: annotation, DI, REST, Data, Security migration |
+| [references/config-map.md](references/config-map.md) | Build module: configuration property migration |
+
+
+## Step 1: Analyze & Choose Strategy
+
+Scan the application to understand what needs to migrate:
+
+- **Build system**: Read `pom.xml` — Spring Boot version, starters, plugins
+- **Java code**: Search for Spring annotations (DI, REST, Data, Security, Scheduling)
+- **Configuration**: Read `application.properties`/`application.yml`, check for profiles
+- **UI / View layer**: Check for Thymeleaf/JSP templates, static resources, Model+View patterns
+- **Tests**: Check for `@SpringBootTest`, `@WebMvcTest`, `@DataJpaTest`
+
+Present a summary table with area, findings, and complexity. Then ask the user to choose a strategy:
+
+- **Spring compat** (recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
+- **Native Quarkus**: Replace all Spring annotations with JAX-RS/CDI. More work, full Quarkus experience.
+
+**Stop here and wait for the user's response before continuing.** Do not ask about git workflow or anything else in the same message.
+
+## Step 2: Git branch (optional)
+
+After the user has chosen a strategy, check if the target project is a git repository. If it is, propose the git workflow:
+
+> **Migration workflow:** Each migration run can be isolated in its own branch (`migration/run-01`, `migration/run-02`, ...) created from `main`. The branch will contain a single commit with all changes plus a migration report. A draft PR against `main` will be created for review — it is never merged, it serves as a permanent diff and discussion record. **Would you like to use this workflow?**
+
+- **User accepts** → follow [modules/git.md](modules/git.md) — **Pre-migration** section. Propose the branch name and wait for confirmation before creating it.
+- **User declines** → skip git management entirely, proceed with migration in the current branch.
+- **Not a git repo** → inform the user, skip git management, proceed normally.
+
+## Step 3: Execute Modules
+
+### Decision Gate Table 
+
+For each module, evaluate whether it applies to this project. A module executes only when its gate is **PASS**. 
+Inspect the project to determine the gate result — do not rely on blind grep commands; use your understanding of the codebase.
+
+| Module                          | Gate Check                                                                                                                | Gate Result                                                                              |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| [jdk](modules/jdk.md)           | JDK 21+ required                                   | **ALWAYS** -- stop migration if < 21 |
+| [build](modules/build.md)       | Spring Boot parent, starters, or spring-boot-maven-plugin in pom.xml                                                      | **PASS** if Spring Boot build markers found; **SKIP** otherwise                          |
+| [code](modules/code.md)         | Spring annotations in Java sources (`@Component`, `@Service`, `@Controller`, `@Repository`, `@Entity`, `@Autowired`, etc.) | **PASS** if Spring annotations found; **SKIP** otherwise                                 |
+| [frontend](modules/frontend.md) | Thymeleaf/JSP templates in `templates/` or static resources in `static/`                                                  | **PASS** if view layer found; **SKIP** otherwise                                         |
+| [testing](modules/testing.md)   | Spring test annotations in test sources (`@SpringBootTest`, `@WebMvcTest`, `@MockBean`)                                   | **PASS** if Spring tests found; **SKIP** otherwise                                       |
+| [cleanup](modules/cleanup.md)   | Leftover Spring artifacts after all other modules                                                                          | **ALWAYS** — runs after all other modules                                                |
+
+### Execution Protocol
+
+```
+FOR module IN [build, code, frontend, testing, cleanup]:
+
+  1. EVALUATE — inspect the project for the gate condition
+  2. DECIDE
+     IF gate == ALWAYS → proceed to step 3
+     IF gate == PASS   → proceed to step 3
+     IF gate == SKIP   → log "Module {name}: SKIPPED — {reason}", mark checkbox, continue
+  3. LOAD — read the module file and relevant reference files
+  4. EXECUTE — follow the module instructions, adapting to the chosen strategy
+  5. COMPILE — run `mvn clean compile -DskipTests`
+     Fails → diagnose and fix before proceeding
+  6. LOG — mark checkbox as done
+```
+
+### Running Individual Modules
+
+To run a single module outside the full migration flow, read its file directly:
+
+- "Read `modules/build.md` and execute it"
+- "Run only the frontend module"
+- "Re-run the cleanup module"
+
+The module will use the current project state and the chosen strategy (if already decided). If no strategy has been chosen, the module will ask.
+
+## Step 4: Verify the Migration
+
+Run each check in order. A check fails = stop and fix before continuing.
+
+| # | Check | Command | Pass criteria |
+|---|-------|---------|---------------|
+| 1 | **Builds** | `mvn clean package -DskipTests` | Exit code 0, no compilation errors |
+| 2 | **No Spring deps** | Search `pom.xml` for `org.springframework` | Zero Spring deps (except Spring compat extensions if using that strategy) |
+| 3 | **Has Quarkus** | Search `pom.xml` for `io.quarkus` | Quarkus BOM and at least one extension present |
+| 4 | **Tests pass** | `mvn test` | All tests pass using `@QuarkusTest` |
+| 5 | **Starts up** | `mvn quarkus:dev` | App starts, `curl http://localhost:8080/q/health` returns UP |
+| 6 | **No leftover templates** | Search for Thymeleaf/JSP references | None remaining (unless intentionally kept) |
+
+## Step 5: Migration Review (Self-Reflection)
+
+Answer each question honestly:
+
+1. **What migrated cleanly?** Patterns that mapped 1:1.
+2. **What required manual judgment?** Non-obvious decisions made.
+3. **What was left as TODO?** Every `// TODO: Migration required` comment and why.
+4. **Was any code removed?** What, where, justification. Flag runtime risks.
+5. **What checks failed initially?** Failures from Step 4 and how you fixed them.
+6. **What's missing from the skill references?** Mappings you had to figure out.
+
+### Migration Report
+
+Present the review as a structured report:
+
+```
+## Migration Report: [app-name]
+
+### Summary
+- Strategy: [Full Migration / Spring Compatibility]
+- Agent: Claude
+- Model: [model name — e.g. claude-sonnet-4-6, check system context]
+- Modules completed: [X/4]
+- Checks passed: [X/6]
+- Token usage: [input tokens / output tokens — check session stats]
+- Estimated cost: [~$X.XX — token counts × per-model pricing from anthropic.com/pricing]
+
+### Changes by Module
+| Module | Files changed | Key changes |
+|--------|--------------|-------------|
+| build | pom.xml, application.properties | ... |
+| code | ... | ... |
+| frontend | ... | ... |
+| testing | ... | ... |
+
+### Validation Results
+| Check | Result | Notes |
+|-------|--------|-------|
+| Builds | PASS/FAIL | |
+| No Spring deps | PASS/FAIL | |
+| Has Quarkus | PASS/FAIL | |
+| Tests pass | PASS/FAIL | |
+| Starts up | PASS/FAIL | |
+| No leftover templates | PASS/FAIL | |
+
+### Unmigrated Code (TODOs)
+| File | Line | What | Why not migrated |
+|------|------|------|-----------------|
+
+### Removed Code
+| File | What was removed | Justification |
+|------|-----------------|---------------|
+
+### Skill Improvement Suggestions
+- [Any missing mappings, unclear instructions, or edge cases discovered]
+```
+
+## Step 6: Commit and PR (only if git workflow was accepted)
+
+Follow [modules/git.md](modules/git.md) — **Post-migration** section. Ask the user for confirmation before committing, and again before pushing / creating the draft PR. Do not proceed with either action without explicit user approval.

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -47,7 +47,7 @@ Scan the application to understand what needs to migrate:
 
 Present a summary table with area, findings, and complexity. Then ask the user to choose a strategy:
 
-- **Spring compat** (recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
+- **Spring compatibility** (recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
 - **Native Quarkus**: Replace all Spring annotations with JAX-RS/CDI. More work, full Quarkus experience.
 
 **Stop here and wait for the user's response before continuing.** Do not ask about git workflow or anything else in the same message.

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -138,7 +138,7 @@ Present the review as a structured report:
 
 ### Summary
 - Strategy: [Full Migration / Spring Compatibility]
-- Agent: Claude
+- Agent: [AI agent name - e.g claude, pi, opencode, gemini, etc]
 - Model: [model name — e.g. claude-sonnet-4-6, check system context]
 - Modules completed: [X/4]
 - Checks passed: [X/6]

--- a/skills/migrate-spring-to-quarkus/modules/build-gradle.md
+++ b/skills/migrate-spring-to-quarkus/modules/build-gradle.md
@@ -1,0 +1,211 @@
+# Sub-module: Build System (Gradle)
+
+Gradle-specific build migration steps. Called from [build.md](build.md).
+Covers both Groovy DSL (`build.gradle`) and Kotlin DSL (`build.gradle.kts`).
+
+Detect which DSL the project uses by the file extension. Use the matching syntax in all examples shown to the user. Do not mix DSLs.
+
+## What to do
+
+- [ ] Replace Spring Boot Gradle plugin with Quarkus Gradle plugin
+- [ ] Remove `io.spring.dependency-management` plugin
+- [ ] Replace Spring dependency management with Quarkus BOM (`enforcedPlatform`)
+- [ ] Configure Java compiler (`-parameters` flag)
+- [ ] Configure test task (JBoss LogManager)
+- [ ] Replace Spring starters with Quarkus equivalents (use dependency-map.md)
+- [ ] Remove unused Spring-only dependencies (`spring-boot-devtools`, etc.)
+- [ ] Compile: `./gradlew clean compileJava -x test`
+
+## Plugin Block
+
+**Groovy DSL** (`build.gradle`):
+
+```groovy
+// BEFORE: Spring Boot
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.x.x'
+    id 'io.spring.dependency-management' version '1.x.x'
+}
+
+// AFTER: Quarkus
+plugins {
+    id 'java'
+    id 'io.quarkus' version "${quarkusPlatformVersion}"
+}
+```
+
+**Kotlin DSL** (`build.gradle.kts`):
+
+```kotlin
+// BEFORE: Spring Boot
+plugins {
+    java
+    id("org.springframework.boot") version "3.x.x"
+    id("io.spring.dependency-management") version "1.x.x"
+}
+
+// AFTER: Quarkus
+plugins {
+    java
+    id("io.quarkus") version(quarkusPlatformVersion)
+}
+```
+
+## Quarkus BOM
+
+Replace Spring's dependency management with Quarkus BOM using `enforcedPlatform`:
+
+**Groovy DSL**:
+
+```groovy
+dependencies {
+    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:${quarkusPlatformVersion}")
+    // extension dependencies — no version numbers needed
+}
+```
+
+**Kotlin DSL**:
+
+```kotlin
+dependencies {
+    implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:${quarkusPlatformVersion}"))
+    // extension dependencies — no version numbers needed
+}
+```
+
+Define the version in `gradle.properties`:
+
+```properties
+quarkusPlatformVersion=3.x.x
+```
+
+Do NOT hardcode the version in the build file — use the latest Quarkus release.
+
+## Java Compiler Configuration
+
+**Groovy DSL**:
+
+```groovy
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs.add('-parameters')
+}
+```
+
+**Kotlin DSL**:
+
+```kotlin
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+tasks.compileJava {
+    options.encoding = "UTF-8"
+    options.compilerArgs.add("-parameters")
+}
+```
+
+## Test Configuration
+
+**Groovy DSL**:
+
+```groovy
+test {
+    systemProperty 'java.util.logging.manager', 'org.jboss.logmanager.LogManager'
+}
+```
+
+**Kotlin DSL**:
+
+```kotlin
+tasks.test {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}
+```
+
+## Native Build Support
+
+Unlike Maven, Gradle does not need a separate profile. The Quarkus Gradle plugin registers native tasks automatically:
+
+```bash
+# Build a native image
+./gradlew build -Dquarkus.native.enabled=true
+```
+
+## Complete Before/After Example
+
+**Groovy DSL** (`build.gradle`):
+
+```groovy
+// BEFORE: Full Spring Boot build.gradle
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.0'
+    id 'io.spring.dependency-management' version '1.1.4'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = '21'
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+// AFTER: Quarkus build.gradle
+plugins {
+    id 'java'
+    id 'io.quarkus' version "${quarkusPlatformVersion}"
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = '21'
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs.add('-parameters')
+}
+
+dependencies {
+    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-rest'
+    implementation 'io.quarkus:quarkus-hibernate-orm-panache'
+    implementation 'io.quarkus:quarkus-jdbc-mysql'
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+test {
+    systemProperty 'java.util.logging.manager', 'org.jboss.logmanager.LogManager'
+}
+```
+
+## Gradle-specific watch out
+
+- **`io.spring.dependency-management` plugin**: Must be removed entirely. Quarkus uses `enforcedPlatform` instead. Leaving both causes version conflicts.
+- **`bootJar` / `bootRun` tasks**: These are Spring Boot plugin tasks. After removing the Spring Boot plugin, they no longer exist. The Quarkus plugin provides `quarkusBuild` and `quarkusDev` instead.
+- **Gradle wrapper**: If the project has `gradlew`/`gradlew.bat`, always use `./gradlew` instead of a system-installed `gradle` command.
+- **Multi-project builds**: If the Spring Boot app is a subproject in a multi-project Gradle build, apply the Quarkus plugin only to the subproject, not the root. The BOM should also be scoped to that subproject's dependencies.
+- **Groovy vs Kotlin DSL**: Detect which DSL the project uses by the file extension (`.gradle` vs `.gradle.kts`). Use the matching syntax. Do not mix DSLs.
+- **`settings.gradle(.kts)`**: Some Spring Boot projects configure plugin management in the settings file. After migration, the Quarkus plugin resolves from the Gradle Plugin Portal by default — no special plugin management is needed.

--- a/skills/migrate-spring-to-quarkus/modules/build-maven.md
+++ b/skills/migrate-spring-to-quarkus/modules/build-maven.md
@@ -10,7 +10,7 @@ Maven-specific build migration steps. Called from [build.md](build.md).
 - [ ] Add `native` profile
 - [ ] Replace Spring starters with Quarkus equivalents (use dependency-map.md)
 - [ ] Remove unused Spring-only dependencies (`spring-boot-devtools`, etc.)
-- [ ] Compile: `mvn clean compile -DskipTests`
+- [ ] Compile: `./mvnw clean compile -DskipTests`
 
 ## pom.xml Reference Snippets
 

--- a/skills/migrate-spring-to-quarkus/modules/build-maven.md
+++ b/skills/migrate-spring-to-quarkus/modules/build-maven.md
@@ -1,0 +1,104 @@
+# Sub-module: Build System (Maven)
+
+Maven-specific build migration steps. Called from [build.md](build.md).
+
+## What to do
+
+- [ ] Replace Spring Boot parent with Quarkus BOM
+- [ ] Replace `spring-boot-maven-plugin` with `quarkus-maven-plugin`
+- [ ] Update `maven-compiler-plugin` and `maven-surefire-plugin`
+- [ ] Add `native` profile
+- [ ] Replace Spring starters with Quarkus equivalents (use dependency-map.md)
+- [ ] Remove unused Spring-only dependencies (`spring-boot-devtools`, etc.)
+- [ ] Compile: `mvn clean compile -DskipTests`
+
+## pom.xml Reference Snippets
+
+**Remove** the Spring Boot parent:
+```xml
+<!-- DELETE this -->
+<parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>...</version>
+</parent>
+```
+
+**Add** Quarkus BOM in `<dependencyManagement>`:
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.platform</groupId>
+            <artifactId>quarkus-bom</artifactId>
+            <version>${quarkus.platform.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+**Add** Quarkus plugin and update compiler/surefire:
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.quarkus.platform</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.platform.version}</version>
+            <extensions>true</extensions>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>build</goal>
+                        <goal>generate-code</goal>
+                        <goal>generate-code-tests</goal>
+                        <goal>native-image-agent</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${compiler-plugin.version}</version>
+            <configuration>
+                <parameters>true</parameters>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <configuration>
+                <systemPropertyVariables>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                </systemPropertyVariables>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+Define `quarkus.platform.version` as a Maven property. Do NOT hardcode the version — use the latest Quarkus release.
+
+**Add** Quarkus native profile:
+
+```xml
+<profiles>
+    <profile>
+        <id>native</id>
+        <activation>
+            <property>
+                <name>native</name>
+            </property>
+        </activation>
+        <properties>
+            <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+            <skipITs>false</skipITs>
+            <quarkus.native.enabled>true</quarkus.native.enabled>
+        </properties>
+    </profile>
+</profiles>
+```

--- a/skills/migrate-spring-to-quarkus/modules/build.md
+++ b/skills/migrate-spring-to-quarkus/modules/build.md
@@ -1,0 +1,123 @@
+# Module: Build System
+
+Migrate the Maven build descriptor and configuration files from Spring Boot to Quarkus.
+
+Load [references/dependency-map.md](../references/dependency-map.md) and [references/config-map.md](../references/config-map.md) before starting.
+
+## What to do
+
+- [ ] Replace Spring Boot parent with Quarkus BOM
+- [ ] Replace `spring-boot-maven-plugin` with `quarkus-maven-plugin`
+- [ ] Update `maven-compiler-plugin` and `maven-surefire-plugin`
+- [ ] Add `native` profile`
+- [ ] Replace Spring starters with Quarkus equivalents (use dependency-map.md)
+- [ ] Migrate `application.properties` / `application.yml` (use config-map.md)
+- [ ] Remove unused Spring-only dependencies (`spring-boot-devtools`, etc.)
+- [ ] Compile: `mvn clean compile -DskipTests`
+
+## pom.xml Reference Snippets
+
+**Remove** the Spring Boot parent:
+```xml
+<!-- DELETE this -->
+<parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>...</version>
+</parent>
+```
+
+**Add** Quarkus BOM in `<dependencyManagement>`:
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.platform</groupId>
+            <artifactId>quarkus-bom</artifactId>
+            <version>${quarkus.platform.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+**Add** Quarkus plugin and update compiler/surefire:
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.quarkus.platform</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.platform.version}</version>
+            <extensions>true</extensions>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>build</goal>
+                        <goal>generate-code</goal>
+                        <goal>generate-code-tests</goal>
+                        <goal>native-image-agent</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${compiler-plugin.version}</version>
+            <configuration>
+                <parameters>true</parameters>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <configuration>
+                <systemPropertyVariables>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                </systemPropertyVariables>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+Define `quarkus.platform.version` as a Maven property. Do NOT hardcode the version — use the latest Quarkus release.
+
+**Add** Quarkus native profile:
+
+```xml
+<profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
+```
+ 
+
+## Configuration Migration
+
+Rename Spring properties to Quarkus equivalents using config-map.md. Key mappings:
+
+- `spring.datasource.*` → `quarkus.datasource.*`
+- `spring.jpa.*` → `quarkus.hibernate-orm.*`
+- `server.port` → `quarkus.http.port`
+- `logging.level.*` → `quarkus.log.category."*".level`
+
+## Watch out
+
+- **Profile handling**: Spring's `application-{profile}.properties` → Quarkus `%profile.` prefix in a single `application.properties`
+- **Naming strategy mismatch**: Spring Boot defaults to snake_case (`firstName` → `first_name`). Quarkus/Hibernate 6 preserves camelCase. Set `quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy`. **Also update `import.sql`/`data.sql` column names**.
+- **`quarkus-spring-boot-properties`** (Spring compat only): `@ConstructorBinding` NOT supported (needs no-arg constructor + setters). `Map<K,V>` types NOT supported.

--- a/skills/migrate-spring-to-quarkus/modules/build.md
+++ b/skills/migrate-spring-to-quarkus/modules/build.md
@@ -1,6 +1,17 @@
 # Module: Build System
 
-Migrate the Maven build descriptor and configuration files from Spring Boot to Quarkus.
+Migrate the build descriptor and configuration files from Spring Boot to Quarkus.
+
+## Gate condition
+
+Detect the build tool by checking which files exist at the project root:
+
+| File | Build tool |
+|---|---|
+| `pom.xml` | Maven |
+| `build.gradle` or `build.gradle.kts` | Gradle |
+
+**This module currently supports Maven only.** If the project uses Gradle, inform the user that Gradle migration is not yet supported by this skill and **skip this module**.
 
 Load [references/dependency-map.md](../references/dependency-map.md) and [references/config-map.md](../references/config-map.md) before starting.
 

--- a/skills/migrate-spring-to-quarkus/modules/build.md
+++ b/skills/migrate-spring-to-quarkus/modules/build.md
@@ -6,117 +6,14 @@ Migrate the build descriptor and configuration files from Spring Boot to Quarkus
 
 Detect the build tool by checking which files exist at the project root:
 
-| File | Build tool |
-|---|---|
-| `pom.xml` | Maven |
-| `build.gradle` or `build.gradle.kts` | Gradle |
-
-**This module currently supports Maven only.** If the project uses Gradle, inform the user that Gradle migration is not yet supported by this skill and **skip this module**.
+| File | Build tool | Sub-module |
+|---|---|---|
+| `pom.xml` | Maven | [build-maven.md](build-maven.md) |
+| `build.gradle` or `build.gradle.kts` | Gradle | [build-gradle.md](build-gradle.md) |
 
 Load [references/dependency-map.md](../references/dependency-map.md) and [references/config-map.md](../references/config-map.md) before starting.
 
-## What to do
-
-- [ ] Replace Spring Boot parent with Quarkus BOM
-- [ ] Replace `spring-boot-maven-plugin` with `quarkus-maven-plugin`
-- [ ] Update `maven-compiler-plugin` and `maven-surefire-plugin`
-- [ ] Add `native` profile`
-- [ ] Replace Spring starters with Quarkus equivalents (use dependency-map.md)
-- [ ] Migrate `application.properties` / `application.yml` (use config-map.md)
-- [ ] Remove unused Spring-only dependencies (`spring-boot-devtools`, etc.)
-- [ ] Compile: `mvn clean compile -DskipTests`
-
-## pom.xml Reference Snippets
-
-**Remove** the Spring Boot parent:
-```xml
-<!-- DELETE this -->
-<parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>...</version>
-</parent>
-```
-
-**Add** Quarkus BOM in `<dependencyManagement>`:
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkus.platform</groupId>
-            <artifactId>quarkus-bom</artifactId>
-            <version>${quarkus.platform.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-```
-
-**Add** Quarkus plugin and update compiler/surefire:
-```xml
-<build>
-    <plugins>
-        <plugin>
-            <groupId>io.quarkus.platform</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus.platform.version}</version>
-            <extensions>true</extensions>
-            <executions>
-                <execution>
-                    <goals>
-                        <goal>build</goal>
-                        <goal>generate-code</goal>
-                        <goal>generate-code-tests</goal>
-                        <goal>native-image-agent</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${compiler-plugin.version}</version>
-            <configuration>
-                <parameters>true</parameters>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <configuration>
-                <systemPropertyVariables>
-                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                </systemPropertyVariables>
-            </configuration>
-        </plugin>
-    </plugins>
-</build>
-```
-
-Define `quarkus.platform.version` as a Maven property. Do NOT hardcode the version — use the latest Quarkus release.
-
-**Add** Quarkus native profile:
-
-```xml
-<profiles>
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
-                <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
-            </properties>
-        </profile>
-    </profiles>
-```
- 
+Then load and execute the matching sub-module above. After the sub-module completes, return here and continue with the Configuration Migration and Watch Out sections below.
 
 ## Configuration Migration
 
@@ -146,3 +43,4 @@ If `application-{profile}.properties` files exist, place production datasource c
 - **Profile handling**: Spring's `application-{profile}.properties` → Quarkus `%profile.` prefix in a single `application.properties`
 - **Naming strategy mismatch**: Spring Boot defaults to snake_case (`firstName` → `first_name`). Quarkus/Hibernate 6 preserves camelCase. Set `quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy`. **Also update `import.sql`/`data.sql` column names**.
 - **`quarkus-spring-boot-properties`** (Spring compat only): `@ConstructorBinding` NOT supported (needs no-arg constructor + setters). `Map<K,V>` types NOT supported.
+- **Gradle wrapper**: If the project has `gradlew`/`gradlew.bat`, always use `./gradlew` instead of a system-installed `gradle` command. Same principle as `mvnw` for Maven.

--- a/skills/migrate-spring-to-quarkus/modules/build.md
+++ b/skills/migrate-spring-to-quarkus/modules/build.md
@@ -43,4 +43,4 @@ If `application-{profile}.properties` files exist, place production datasource c
 - **Profile handling**: Spring's `application-{profile}.properties` → Quarkus `%profile.` prefix in a single `application.properties`
 - **Naming strategy mismatch**: Spring Boot defaults to snake_case (`firstName` → `first_name`). Quarkus/Hibernate 6 preserves camelCase. Set `quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy`. **Also update `import.sql`/`data.sql` column names**.
 - **`quarkus-spring-boot-properties`** (Spring compat only): `@ConstructorBinding` NOT supported (needs no-arg constructor + setters). `Map<K,V>` types NOT supported.
-- **Gradle wrapper**: If the project has `gradlew`/`gradlew.bat`, always use `./gradlew` instead of a system-installed `gradle` command. Same principle as `mvnw` for Maven.
+- **Build tool wrapper**: If the project has `mvnw`/`gradlew`, always use `./mvnw` or `./gradlew` instead of the system-installed `mvn` or `gradle` command. This ensures reproducible builds with the exact tool version the project expects.

--- a/skills/migrate-spring-to-quarkus/modules/build.md
+++ b/skills/migrate-spring-to-quarkus/modules/build.md
@@ -111,10 +111,24 @@ Define `quarkus.platform.version` as a Maven property. Do NOT hardcode the versi
 
 Rename Spring properties to Quarkus equivalents using config-map.md. Key mappings:
 
-- `spring.datasource.*` → `quarkus.datasource.*`
+- `spring.datasource.*` → `%prod.quarkus.datasource.*` (see below)
 - `spring.jpa.*` → `quarkus.hibernate-orm.*`
 - `server.port` → `quarkus.http.port`
 - `logging.level.*` → `quarkus.log.category."*".level`
+
+### Datasource properties and Dev Services
+
+When the project has no `application-{profile}.properties` files, prefix datasource connection properties with `%prod.` so they only apply in production. This lets Quarkus Dev Services automatically start a containerized database in dev and test modes — no local database setup needed.
+
+```properties
+
+# connection details only for prod
+%prod.quarkus.datasource.jdbc.url=jdbc:mysql://127.0.0.1:3306/todo
+%prod.quarkus.datasource.username=root
+%prod.quarkus.datasource.password=root
+```
+
+If `application-{profile}.properties` files exist, place production datasource config in `application-prod.properties` instead (no `%prod.` prefix needed there).
 
 ## Watch out
 

--- a/skills/migrate-spring-to-quarkus/modules/cleanup.md
+++ b/skills/migrate-spring-to-quarkus/modules/cleanup.md
@@ -1,0 +1,48 @@
+# Module: Cleanup
+
+Remove leftover Spring artifacts that survived the per-module migration: orphaned imports, unused dependencies, stale configuration, and the Spring Boot main class (if not already removed).
+
+## What to do
+
+- [ ] Remove the `@SpringBootApplication` main class (if still present)
+- [ ] Remove leftover Spring imports from all Java files
+- [ ] Remove unused Spring dependencies from `pom.xml`
+- [ ] Remove stale Spring configuration properties
+- [ ] Remove orphaned Spring config files (`application-*.properties/yml` that have no Quarkus equivalent)
+- [ ] Compile: `mvn clean compile -DskipTests`
+
+## Main class removal
+
+Quarkus auto-generates a main class — delete the `@SpringBootApplication` file. But first, check if it contains anything that needs migrating:
+
+- `@Bean` methods → move to an `@ApplicationScoped` class with `@Produces`
+- `CommandLineRunner` / `ApplicationRunner` → `void onStart(@Observes StartupEvent event)`
+- `@EnableScheduling`, `@EnableCaching`, etc. → not needed, Quarkus enables these via extensions
+
+If the main class was already removed during the code module, mark this as done.
+
+## Leftover Spring imports
+
+Search all Java files for remaining `org.springframework.*` imports:
+
+```bash
+grep -rn "import org.springframework" src/
+```
+
+For each hit:
+- If the class has a Quarkus/Jakarta equivalent → replace the import (use annotation-map.md)
+- If it's an unused import → delete it
+- If it's still needed (Spring compat strategy) → leave it, but verify the corresponding `quarkus-spring-*` extension is in `pom.xml`
+
+## Unused Spring dependencies
+
+Check `pom.xml` for Spring dependencies that are no longer referenced anywhere in the code:
+
+- `spring-boot-devtools` → always remove (no Quarkus equivalent; use `quarkus:dev` instead)
+- `spring-boot-configuration-processor` → remove (Quarkus uses build-time config)
+- `spring-boot-starter-actuator` → remove if replaced by `quarkus-smallrye-health` / `quarkus-micrometer`
+- Any `spring-boot-starter-*` without matching code usage → remove
+
+## Stale configuration
+
+Check `application.properties` / `application.yml` for properties still using `spring.*` prefix that were missed during the build module. Either migrate them using config-map.md or remove them if the feature they configure no longer exists.

--- a/skills/migrate-spring-to-quarkus/modules/cleanup.md
+++ b/skills/migrate-spring-to-quarkus/modules/cleanup.md
@@ -9,7 +9,7 @@ Remove leftover Spring artifacts that survived the per-module migration: orphane
 - [ ] Remove unused Spring dependencies from the build file (`pom.xml` or `build.gradle(.kts)`)
 - [ ] Remove stale Spring configuration properties
 - [ ] Remove orphaned Spring config files (`application-*.properties/yml` that have no Quarkus equivalent)
-- [ ] Compile: `mvn clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
+- [ ] Compile: `./mvnw clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
 
 ## Main class removal
 

--- a/skills/migrate-spring-to-quarkus/modules/cleanup.md
+++ b/skills/migrate-spring-to-quarkus/modules/cleanup.md
@@ -13,13 +13,9 @@ Remove leftover Spring artifacts that survived the per-module migration: orphane
 
 ## Main class removal
 
-Quarkus auto-generates a main class — delete the `@SpringBootApplication` file. But first, check if it contains anything that needs migrating:
-
-- `@Bean` methods → move to an `@ApplicationScoped` class with `@Produces`
-- `CommandLineRunner` / `ApplicationRunner` → `void onStart(@Observes StartupEvent event)`
-- `@EnableScheduling`, `@EnableCaching`, etc. → not needed, Quarkus enables these via extensions
-
 If the main class was already removed during the code module, mark this as done.
+
+Otherwise, follow the instructions in the [code module — Main Class Removal](./code.md#main-class-removal).
 
 ## Leftover Spring imports
 

--- a/skills/migrate-spring-to-quarkus/modules/cleanup.md
+++ b/skills/migrate-spring-to-quarkus/modules/cleanup.md
@@ -6,10 +6,10 @@ Remove leftover Spring artifacts that survived the per-module migration: orphane
 
 - [ ] Remove the `@SpringBootApplication` main class (if still present)
 - [ ] Remove leftover Spring imports from all Java files
-- [ ] Remove unused Spring dependencies from `pom.xml`
+- [ ] Remove unused Spring dependencies from the build file (`pom.xml` or `build.gradle(.kts)`)
 - [ ] Remove stale Spring configuration properties
 - [ ] Remove orphaned Spring config files (`application-*.properties/yml` that have no Quarkus equivalent)
-- [ ] Compile: `mvn clean compile -DskipTests`
+- [ ] Compile: `mvn clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
 
 ## Main class removal
 
@@ -28,11 +28,11 @@ grep -rn "import org.springframework" src/
 For each hit:
 - If the class has a Quarkus/Jakarta equivalent → replace the import (use annotation-map.md)
 - If it's an unused import → delete it
-- If it's still needed (Spring compat strategy) → leave it, but verify the corresponding `quarkus-spring-*` extension is in `pom.xml`
+- If it's still needed (Spring compat strategy) → leave it, but verify the corresponding `quarkus-spring-*` extension is in the build file
 
 ## Unused Spring dependencies
 
-Check `pom.xml` for Spring dependencies that are no longer referenced anywhere in the code:
+Check the build file (`pom.xml` or `build.gradle(.kts)`) for Spring dependencies that are no longer referenced anywhere in the code:
 
 - `spring-boot-devtools` → always remove (no Quarkus equivalent; use `quarkus:dev` instead)
 - `spring-boot-configuration-processor` → remove (Quarkus uses build-time config)

--- a/skills/migrate-spring-to-quarkus/modules/code.md
+++ b/skills/migrate-spring-to-quarkus/modules/code.md
@@ -1,0 +1,182 @@
+. 
+
+Migrate all Java source code from Spring patterns to Quarkus equivalents.
+
+Load [references/annotation-map.md](../references/annotation-map.md) before starting. It contains the complete annotation mapping tables for DI, REST, Data, Security, Cache, Scheduling, and Lifecycle.
+
+## What to do
+
+- [ ] Migrate entities (JPA → Panache if native strategy)
+- [ ] Migrate repositories (Spring Data → Panache if native strategy)
+- [ ] Simplify service layer (remove unnecessary interface+impl)
+- [ ] Migrate controllers/resources (Spring MVC → JAX-RS if native strategy)
+- [ ] Migrate DI annotations (`@Autowired` → `@Inject`, `@Component` → `@ApplicationScoped`, etc.)
+- [ ] Migrate `Model.addAttribute()` → Qute `Template.data()` or `@CheckedTemplate`
+- [ ] Migrate `return "redirect:..."` → `Response.seeOther()`
+- [ ] Remove `@SpringBootApplication` main class
+- [ ] Compile: `mvn clean compile -DskipTests`
+
+Use the annotation-map.md reference for the full mapping. Below are the key patterns with before/after examples.
+
+## Entity Layer (Native strategy)
+
+```java
+// BEFORE: Spring Data JPA
+@Entity
+public class Todo {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private boolean completed;
+    // getters + setters
+}
+
+// AFTER: Panache Active Record
+@Entity
+public class Todo extends PanacheEntity {
+    public String title;
+    public boolean completed;
+    // id provided by PanacheEntity — remove @Id and @GeneratedValue
+    // public fields — remove getters/setters
+}
+```
+
+## Repository Layer (Native strategy)
+
+Two patterns available — choose based on project conventions:
+
+**Active Record** (queries on the entity):
+```java
+// Static methods on the entity
+public static List<Todo> findByCompleted(boolean completed) {
+    return list("completed", completed);
+}
+// Usage: Todo.listAll(), Todo.findById(id), Todo.findByCompleted(true)
+```
+
+**Repository class** (separate from entity):
+```java
+@ApplicationScoped
+public class TodoRepository implements PanacheRepository<Todo> {
+    public List<Todo> findByCompleted(boolean completed) {
+        return list("completed", completed);
+    }
+}
+```
+
+**Pagination** (replaces Spring's `Page<T>` + `Pageable`):
+```java
+PanacheQuery<Todo> query = find("completed", completed);
+query.page(Page.of(page, size));
+long totalCount = query.count();
+List<Todo> items = query.list();
+```
+
+**Spring compat strategy**: Keep `JpaRepository`/`CrudRepository` — they work with `quarkus-spring-data-jpa`.
+
+## Service Layer
+
+Spring services often use interface + implementation unnecessarily. Simplify:
+
+```java
+// BEFORE: Spring — interface + impl
+public interface TodoService { List<Todo> findAll(); }
+
+@Service
+public class TodoServiceImpl implements TodoService {
+    @Autowired private TodoRepository repository;
+    @Override public List<Todo> findAll() { return repository.findAll(); }
+}
+
+// AFTER: Quarkus — single class
+@ApplicationScoped
+public class TodoService {
+    @Inject TodoRepository repository;
+    public List<Todo> findAll() { return repository.listAll(); }
+}
+```
+
+**Decision guide:**
+- Service only delegates to repository → eliminate it, inject repository directly in the resource
+- Service has real business logic → keep as `@ApplicationScoped`, remove the interface
+- Interface used for testing/mocking → not needed, `@InjectMock` works on concrete classes
+
+**Spring compat strategy**: `@Service` is supported by `quarkus-spring-di` — no changes needed.
+
+## Controller → Resource (Native strategy)
+
+```java
+// BEFORE: Spring MVC
+@Controller
+public class TodoController {
+    @GetMapping("/todos")
+    public String list(Model model) {
+        model.addAttribute("todos", todoService.findAll());
+        return "todos";
+    }
+
+    @PostMapping("/todos")
+    public String create(@ModelAttribute Todo todo) {
+        todoService.save(todo);
+        return "redirect:/todos";
+    }
+}
+
+// AFTER: Quarkus + JAX-RS + Qute
+@Path("/todos")
+@ApplicationScoped
+public class TodoResource {
+    @Inject TodoService todoService;
+
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance todos(List<Todo> todos);
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance list() {
+        return Templates.todos(todoService.findAll());
+    }
+
+    @POST
+    @Transactional
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response create(@BeanParam Todo todo) {
+        todoService.save(todo);
+        return Response.seeOther(URI.create("/todos")).build();
+    }
+}
+```
+
+**Qute strict data map** — unlike Thymeleaf, Qute throws `TemplateException` if a key referenced in the template is missing from the data map. Every `.data()` call site must provide the **same complete set of keys**, including on empty-result paths.
+
+**Spring compat strategy**: `@RestController` works with `quarkus-spring-web` (but NOT plain `@Controller`).
+
+## Main Class Removal
+
+Quarkus auto-generates a main class — delete the `@SpringBootApplication` file. But first, migrate anything it contains:
+
+- `@Bean` methods → move to an `@ApplicationScoped` class with `@Produces`
+- `CommandLineRunner` / `ApplicationRunner` → `void onStart(@Observes StartupEvent event)`
+
+## Watch out
+
+- **Missing `@Transactional`**: Quarkus uses `jakarta.transaction.Transactional`, not Spring's
+- **Bean discovery**: Quarkus uses build-time CDI; beans must have a scope annotation
+- **No OSIV**: Quarkus doesn't have Open Session in View; lazy loading outside transactions will fail
+- **No component scanning**: Beans in external JARs need a Jandex index or `quarkus.index-dependency`
+- **JAX-RS path conflicts**: Spring allows overlapping `@RequestMapping` paths — JAX-RS does not. Check for duplicate `@Path` values
+
+## Spring Compat Extension Limitations
+
+When using the compatibility strategy (`quarkus-spring-*` extensions), be aware of these **verified limitations from the Quarkus source code**:
+
+| Extension | What does NOT work |
+|---|---|
+| `quarkus-spring-di` | `@Primary`, `@Conditional*`, `@Profile`, `@Lazy` not processed. SpEL `#{...}` in `@Value` throws error. `@Bean` must be inside `@Configuration` class. |
+| `quarkus-spring-web` | Only `@RestController` — plain `@Controller` not supported. Only one `@RestControllerAdvice` per app. `@CrossOrigin`, `@InitBinder`, `@ModelAttribute` not supported. No reactive types (`Mono`, `Flux`). |
+| `quarkus-spring-security` | Limited SpEL in `@PreAuthorize`: only `hasRole`, `hasAnyRole`, `permitAll`, `denyAll`, `isAuthenticated`, `@bean.method()`, param comparison. Cannot mix `and`/`or` operators. Cannot combine `@Secured` with `@PreAuthorize`. |
+| `quarkus-spring-data-jpa` | SpEL `#{...}` in `@Query` not supported. No `Distinct` queries. Limited custom repository fragment support. |
+| `quarkus-spring-cache` | Single cache name only (no arrays). `key`, `condition`, `unless`, `keyGenerator`, `cacheManager` parameters NOT supported. No `@Caching` or `@CacheConfig`. |
+| `quarkus-spring-scheduled` | `fixedDelay` NOT supported (only `fixedRate`). Cannot combine `initialDelay` with `cron`. |

--- a/skills/migrate-spring-to-quarkus/modules/code.md
+++ b/skills/migrate-spring-to-quarkus/modules/code.md
@@ -155,10 +155,14 @@ public class TodoResource {
 
 ## Main Class Removal
 
-Quarkus auto-generates a main class — delete the `@SpringBootApplication` file. But first, migrate anything it contains:
+If the main class **only** contains `SpringApplication.run(...)`, delete it — Quarkus auto-generates a main class.
+
+If it contains additional logic, migrate before deleting:
 
 - `@Bean` methods → move to an `@ApplicationScoped` class with `@Produces`
-- `CommandLineRunner` / `ApplicationRunner` → `void onStart(@Observes StartupEvent event)`
+- `CommandLineRunner` → `@QuarkusMain` with `QuarkusApplication`, or `@TopCommand` (Picocli) if it parses CLI arguments
+- `ApplicationRunner` → `@QuarkusMain` implementing `QuarkusApplication`
+- `@EnableScheduling`, `@EnableCaching`, etc. → not needed, Quarkus enables these via extensions
 
 ## Watch out
 

--- a/skills/migrate-spring-to-quarkus/modules/code.md
+++ b/skills/migrate-spring-to-quarkus/modules/code.md
@@ -164,6 +164,129 @@ If it contains additional logic, migrate before deleting:
 - `ApplicationRunner` → `@QuarkusMain` implementing `QuarkusApplication`
 - `@EnableScheduling`, `@EnableCaching`, etc. → not needed, Quarkus enables these via extensions
 
+### @Bean methods
+
+```java
+// BEFORE: Spring — @Bean in main class
+@SpringBootApplication
+public class MyApp {
+    public static void main(String[] args) { SpringApplication.run(MyApp.class, args); }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+}
+
+// AFTER: Quarkus — @Produces in a dedicated class
+@ApplicationScoped
+public class AppConfig {
+    @Produces
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+}
+```
+
+### CommandLineRunner → @QuarkusMain
+
+Use `@QuarkusMain` when the runner executes startup logic without parsing CLI arguments.
+
+```java
+// BEFORE: Spring — CommandLineRunner
+@SpringBootApplication
+public class MyApp implements CommandLineRunner {
+    @Autowired DataLoader dataLoader;
+
+    public static void main(String[] args) { SpringApplication.run(MyApp.class, args); }
+
+    @Override
+    public void run(String... args) {
+        dataLoader.seed();
+    }
+}
+
+// AFTER: Quarkus — @QuarkusMain
+@QuarkusMain
+public class MyApp implements QuarkusApplication {
+    @Inject DataLoader dataLoader;
+
+    @Override
+    public int run(String... args) {
+        dataLoader.seed();
+        Quarkus.waitForExit();
+        return 0;
+    }
+}
+```
+
+### CommandLineRunner with CLI arguments → @TopCommand (Picocli)
+
+Use `@TopCommand` when the runner parses command-line arguments.
+
+```java
+// BEFORE: Spring — CommandLineRunner parsing args
+@SpringBootApplication
+public class MyCli implements CommandLineRunner {
+    public static void main(String[] args) { SpringApplication.run(MyCli.class, args); }
+
+    @Override
+    public void run(String... args) {
+        String file = args[0];
+        process(file);
+    }
+}
+
+// AFTER: Quarkus — Picocli @TopCommand
+@TopCommand
+@CommandLine.Command(name = "mycli", mixinStandardHelpOptions = true)
+public class MyCli implements Runnable {
+    @CommandLine.Parameters(index = "0", description = "File to process")
+    String file;
+
+    @Override
+    public void run() {
+        process(file);
+    }
+}
+// Requires: quarkus-picocli extension
+```
+
+### ApplicationRunner → @QuarkusMain
+
+```java
+// BEFORE: Spring — ApplicationRunner
+@SpringBootApplication
+public class MyApp implements ApplicationRunner {
+    @Autowired MigrationService migrations;
+
+    public static void main(String[] args) { SpringApplication.run(MyApp.class, args); }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (args.containsOption("migrate")) {
+            migrations.execute();
+        }
+    }
+}
+
+// AFTER: Quarkus — @QuarkusMain
+@QuarkusMain
+public class MyApp implements QuarkusApplication {
+    @Inject MigrationService migrations;
+
+    @Override
+    public int run(String... args) {
+        List<String> argList = List.of(args);
+        if (argList.contains("--migrate")) {
+            migrations.execute();
+        }
+        Quarkus.waitForExit();
+        return 0;
+    }
+}
+```
+
 ## Watch out
 
 - **Missing `@Transactional`**: Quarkus uses `jakarta.transaction.Transactional`, not Spring's

--- a/skills/migrate-spring-to-quarkus/modules/code.md
+++ b/skills/migrate-spring-to-quarkus/modules/code.md
@@ -14,7 +14,7 @@ Load [references/annotation-map.md](../references/annotation-map.md) before star
 - [ ] Migrate `Model.addAttribute()` → Qute `Template.data()` or `@CheckedTemplate`
 - [ ] Migrate `return "redirect:..."` → `Response.seeOther()`
 - [ ] Remove `@SpringBootApplication` main class
-- [ ] Compile: `mvn clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
+- [ ] Compile: `./mvnw clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
 
 Use the annotation-map.md reference for the full mapping. Below are the key patterns with before/after examples.
 

--- a/skills/migrate-spring-to-quarkus/modules/code.md
+++ b/skills/migrate-spring-to-quarkus/modules/code.md
@@ -14,7 +14,7 @@ Load [references/annotation-map.md](../references/annotation-map.md) before star
 - [ ] Migrate `Model.addAttribute()` → Qute `Template.data()` or `@CheckedTemplate`
 - [ ] Migrate `return "redirect:..."` → `Response.seeOther()`
 - [ ] Remove `@SpringBootApplication` main class
-- [ ] Compile: `mvn clean compile -DskipTests`
+- [ ] Compile: `mvn clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
 
 Use the annotation-map.md reference for the full mapping. Below are the key patterns with before/after examples.
 

--- a/skills/migrate-spring-to-quarkus/modules/frontend.md
+++ b/skills/migrate-spring-to-quarkus/modules/frontend.md
@@ -1,0 +1,90 @@
+# Module: Frontend / View Layer
+
+Migrate templates, static assets, and view-related code from Spring MVC + Thymeleaf to Quarkus + Qute.
+
+## What to do
+
+- [ ] Ensure `quarkus-rest-qute` dependency is in `pom.xml`
+- [ ] Convert Thymeleaf templates to Qute syntax
+- [ ] Move static resources from `static/` to `META-INF/resources/`
+- [ ] Remove Spring CSRF tokens from HTML and JavaScript
+- [ ] Rename template directories to match `@CheckedTemplate` class names
+- [ ] Compile: `mvn clean compile -DskipTests`
+
+## Dependency
+
+Use `quarkus-rest-qute` — **never** `quarkus-qute` alone:
+
+```xml
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-rest-qute</artifactId>
+</dependency>
+```
+
+`quarkus-qute` is the standalone engine without REST integration. It will fail at runtime when JAX-RS resources return `TemplateInstance`. `quarkus-rest-qute` includes Qute and adds the REST integration layer.
+
+## Thymeleaf → Qute Syntax Conversion
+
+| Thymeleaf | Qute | Notes |
+|---|---|---|
+| `th:text="${name}"` | `{name}` | Direct expression |
+| `th:utext="${html}"` | `{html.raw}` | Unescaped HTML output |
+| `th:each="item : ${items}"` | `{#for item in items}...{/for}` | Loop |
+| `th:if="${condition}"` | `{#if condition}...{/if}` | Conditional |
+| `th:unless="${condition}"` | `{#if !condition}...{/if}` | Negated conditional |
+| `th:href="@{/path/{id}(id=${item.id})}"` | `href="/path/{item.id}"` | URL with path param |
+| `th:action="@{/submit}"` | `action="/submit"` | Form action |
+| `th:value="${value}"` | `value="{value}"` | Input value |
+| `th:class="${active ? 'on' : 'off'}"` | `class="{active ? 'on' : 'off'}"` | Conditional class |
+| `th:fragment="name"` | `{#include name /}` | Template fragment/include |
+
+## Template File Location
+
+When using `@CheckedTemplate`, template files must match the enclosing class name:
+
+```
+templates/todos.html                    → templates/TodoResource/todos.html
+templates/todo-detail.html              → templates/TodoResource/todoDetail.html
+```
+
+## Qute Strict Data Map (Critical)
+
+Unlike Thymeleaf (which silently treats missing variables as null), Qute throws `TemplateException` if a template key is missing from the data map. **Every `.data()` call site must provide the same complete set of keys.** For example, if the template references `tasks`, `noTasks`, `totalPages`:
+
+- The **empty-result** path must include: `.data("tasks", List.of()).data("noTasks", true).data("totalPages", 0)`
+- The **has-results** path must include: `.data("noTasks", false)` in addition to actual data
+
+Start migration with `quarkus.qute.strict-rendering=false` and `quarkus.qute.property-not-found-strategy=output-original`, fix all missing variables, then enable strict mode.
+
+## Static Assets
+
+```
+# BEFORE (Spring Boot)
+src/main/resources/static/css/style.css
+src/main/resources/static/js/app.js
+
+# AFTER (Quarkus)
+src/main/resources/META-INF/resources/css/style.css
+src/main/resources/META-INF/resources/js/app.js
+```
+
+## CSRF Token Removal
+
+Quarkus does not use Spring Security's CSRF mechanism. Remove these from templates and JavaScript:
+
+```html
+<!-- DELETE from HTML: -->
+<meta name="_csrf" th:content="${_csrf.token}"/>
+<meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+```
+
+```javascript
+// DELETE from JS:
+const token = document.querySelector('meta[name="_csrf"]').content;
+const header = document.querySelector('meta[name="_csrf_header"]').content;
+headers[header] = token;
+```
+
+If the app needs CSRF protection in Quarkus, use `quarkus-csrf-reactive`.

--- a/skills/migrate-spring-to-quarkus/modules/frontend.md
+++ b/skills/migrate-spring-to-quarkus/modules/frontend.md
@@ -4,22 +4,28 @@ Migrate templates, static assets, and view-related code from Spring MVC + Thymel
 
 ## What to do
 
-- [ ] Ensure `quarkus-rest-qute` dependency is in `pom.xml`
+- [ ] Ensure `quarkus-rest-qute` dependency is in the build file
 - [ ] Convert Thymeleaf templates to Qute syntax
 - [ ] Move static resources from `static/` to `META-INF/resources/`
 - [ ] Remove Spring CSRF tokens from HTML and JavaScript
 - [ ] Rename template directories to match `@CheckedTemplate` class names
-- [ ] Compile: `mvn clean compile -DskipTests`
+- [ ] Compile: `mvn clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
 
 ## Dependency
 
 Use `quarkus-rest-qute` — **never** `quarkus-qute` alone:
 
+**Maven:**
 ```xml
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-rest-qute</artifactId>
 </dependency>
+```
+
+**Gradle:**
+```groovy
+implementation 'io.quarkus:quarkus-rest-qute'
 ```
 
 `quarkus-qute` is the standalone engine without REST integration. It will fail at runtime when JAX-RS resources return `TemplateInstance`. `quarkus-rest-qute` includes Qute and adds the REST integration layer.

--- a/skills/migrate-spring-to-quarkus/modules/frontend.md
+++ b/skills/migrate-spring-to-quarkus/modules/frontend.md
@@ -9,7 +9,7 @@ Migrate templates, static assets, and view-related code from Spring MVC + Thymel
 - [ ] Move static resources from `static/` to `META-INF/resources/`
 - [ ] Remove Spring CSRF tokens from HTML and JavaScript
 - [ ] Rename template directories to match `@CheckedTemplate` class names
-- [ ] Compile: `mvn clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
+- [ ] Compile: `./mvnw clean compile -DskipTests` (Maven) or `./gradlew clean compileJava -x test` (Gradle)
 
 ## Dependency
 

--- a/skills/migrate-spring-to-quarkus/modules/git.md
+++ b/skills/migrate-spring-to-quarkus/modules/git.md
@@ -77,6 +77,24 @@ Where `XX` is the next sequential number (zero-padded to two digits). If no prio
 
 ## Commit
 
+### Pre-commit: check for secrets
+
+Before staging files, scan the working directory for accidentally exposed secrets. Search for patterns like:
+
+- Hardcoded tokens or API keys (e.g., `ghp_`, `ghs_`, `sk-`, `Bearer`, `AKIA`)
+- Password or credential values in plain text
+- Private keys (`-----BEGIN.*PRIVATE KEY-----`)
+- `.env` files or agent session logs that slipped past `.gitignore`
+
+```bash
+grep -rn --include='*.java' --include='*.properties' --include='*.yml' --include='*.md' --include='*.json' \
+  -E '(ghp_|ghs_|sk-|AKIA|Bearer [A-Za-z0-9]|password\s*=\s*[^\$]|BEGIN.*PRIVATE KEY)' .
+```
+
+If any matches are found, flag them to the user before proceeding. Do **not** commit files containing secrets.
+
+### Stage and commit
+
 After migration and verification are complete, show the user a summary of staged changes and ask for confirmation:
 
 > Migration complete. Ready to commit all changes (including `migration-report.md`) with message:

--- a/skills/migrate-spring-to-quarkus/modules/git.md
+++ b/skills/migrate-spring-to-quarkus/modules/git.md
@@ -1,0 +1,84 @@
+# Module: Git / Branch Management
+
+**Optional module.** Set up an isolated migration branch before making changes, and commit + open a draft PR after the migration is verified. Requires user confirmation at every step.
+
+## Prerequisites
+
+Verify the target project is a git repository:
+
+```bash
+git -C <project-path> rev-parse --is-inside-work-tree
+```
+
+If this fails, **skip this module entirely** — inform the user that git management is not available because the project is not a git repository.
+
+## Agent Name
+
+The agent performing this migration is **Claude** by default. If this migration was run using a different tool (Copilot, Cursor, Junie, etc.), replace `Claude` with the appropriate name throughout this module.
+
+## What to do
+
+### Pre-migration (before executing modules)
+
+- [ ] Verify the project is a git repository
+- [ ] Determine the next run number from existing branches
+- [ ] Propose branch name to the user and wait for confirmation
+- [ ] Create the migration branch
+
+### Post-migration (after verification)
+
+- [ ] Write `migration-report.md` at the repo root
+- [ ] Show the user a summary of changes and ask for confirmation before committing
+- [ ] Ask the user for confirmation before pushing and creating the draft PR
+
+## Create the migration branch
+
+Determine the next run number from existing branches:
+
+```bash
+git branch -a --list '*migration/run-*' | sort -t- -k3 -n | tail -1
+```
+
+Propose the branch name to the user:
+
+> I'll create branch `migration/run-XX` from `main`. OK, or do you prefer a different name?
+
+Wait for the user to confirm or provide a custom name. Then create the branch:
+
+```bash
+git checkout main
+git checkout -b <confirmed-branch-name>
+```
+
+Where `XX` is the next sequential number (zero-padded to two digits). If no prior branches exist, start with `migration/run-01`.
+
+## Commit
+
+After migration and verification are complete, show the user a summary of staged changes and ask for confirmation:
+
+> Migration complete. Ready to commit all changes (including `migration-report.md`) with message:
+>
+> ```
+> Migrate Spring Boot to Quarkus
+>
+> Migrated by Claude using skill spring-to-quarkus
+> ```
+>
+> Proceed?
+
+Only commit after the user confirms.
+
+## Push and create draft PR
+
+Ask the user for confirmation before pushing:
+
+> Ready to push `<branch-name>` to `origin` and create a draft PR. Proceed?
+
+```bash
+git push origin <branch-name>
+gh pr create --draft \
+  --title "<branch-name>: Spring Boot → Quarkus migration" \
+  --body "$(cat migration-report.md)"
+```
+
+The draft PR is a permanent record — never merge it. `main` always keeps the original Spring Boot code. Use labels to categorize runs (e.g., `strategy:native`, `strategy:spring-compat`).

--- a/skills/migrate-spring-to-quarkus/modules/git.md
+++ b/skills/migrate-spring-to-quarkus/modules/git.md
@@ -12,15 +12,12 @@ git -C <project-path> rev-parse --is-inside-work-tree
 
 If this fails, **skip this module entirely** — inform the user that git management is not available because the project is not a git repository.
 
-## Agent Name
-
-The agent performing this migration is **Claude** by default. If this migration was run using a different tool (Copilot, Cursor, Junie, etc.), replace `Claude` with the appropriate name throughout this module.
-
 ## What to do
 
 ### Pre-migration (before executing modules)
 
 - [ ] Verify the project is a git repository
+- [ ] Ensure agent session files are excluded from version control
 - [ ] Determine the next run number from existing branches
 - [ ] Propose branch name to the user and wait for confirmation
 - [ ] Create the migration branch
@@ -30,6 +27,32 @@ The agent performing this migration is **Claude** by default. If this migration 
 - [ ] Write `migration-report.md` at the repo root
 - [ ] Show the user a summary of changes and ask for confirmation before committing
 - [ ] Ask the user for confirmation before pushing and creating the draft PR
+
+## Exclude agent session files
+
+Before any commit, ensure that agent session directories are listed in the project's `.gitignore`. These directories may contain sensitive data (tokens, credentials) logged during tool execution.
+
+Append the following entries to `.gitignore` if they are not already present:
+
+```
+# AI agent session/local files — may contain tokens and secrets
+.claude/
+.cursor/
+.codex/
+.opencode/
+.copilot/
+.cline/
+.continue/
+.windsurf/
+.junie/
+.pi/
+.roo/
+.augment/
+.aider*
+CLAUDE.local.md
+```
+
+This prevents session logs from being committed and pushed to the remote repository.
 
 ## Create the migration branch
 

--- a/skills/migrate-spring-to-quarkus/modules/jdk.md
+++ b/skills/migrate-spring-to-quarkus/modules/jdk.md
@@ -1,0 +1,26 @@
+---
+name: jdk
+description: Checks the JDK installed and selected before starting the migration. Warns the user and stops if the requirement is not met.
+license: Apache-2.0
+metadata:
+  author: Quarkus Team - https://github.com/quarkusio/quarkus
+  version: "0.1.0"
+---
+
+# Phase 0: Check JDK Version
+
+Verify that the installed JDK meets the version requirement using the user's prompt VERSION before proceeding with the migration.
+
+## Preconditions
+
+This phase has no preconditions — it must **always** run as the very first step.
+
+## Instructions
+
+- **DO NOT** skip this phase.
+- Capture the VERSION parameter from the prompt.
+- [ ] Check the JDK version.
+- [ ] If the version is **>= VERSION**, mark this phase as passed and proceed to the next phase
+- [ ] If the version is **< VERSION** or `java` is not found:
+    - **Warn the user**: "JDK VERSION or later is required for this migration. Currently, installed: <detected version or 'none'>. Please install JDK VERSION and ensure it is on your PATH before retrying."
+    - **Stop the migration** — do not proceed to any subsequent phase

--- a/skills/migrate-spring-to-quarkus/modules/jdk.md
+++ b/skills/migrate-spring-to-quarkus/modules/jdk.md
@@ -1,12 +1,3 @@
----
-name: jdk
-description: Checks the JDK installed and selected before starting the migration. Warns the user and stops if the requirement is not met.
-license: Apache-2.0
-metadata:
-  author: Quarkus Team - https://github.com/quarkusio/quarkus
-  version: "0.1.0"
----
-
 # Phase 0: Check JDK Version
 
 Verify that the installed JDK meets the version requirement using the user's prompt VERSION before proceeding with the migration.

--- a/skills/migrate-spring-to-quarkus/modules/testing.md
+++ b/skills/migrate-spring-to-quarkus/modules/testing.md
@@ -1,0 +1,76 @@
+# Module: Testing
+
+Migrate test infrastructure from Spring Boot Test to Quarkus Test.
+
+Load [references/annotation-map.md](../references/annotation-map.md) — see the Testing section for full mapping.
+
+## What to do
+
+- [ ] Replace `@SpringBootTest` with `@QuarkusTest`
+- [ ] Replace `@MockBean` with `@InjectMock` (`io.quarkus.test.InjectMock`)
+- [ ] Replace `TestRestTemplate` with REST Assured
+- [ ] Replace `@ActiveProfiles("test")` with `@TestProfile`
+- [ ] Replace `@LocalServerPort` with `@TestHTTPResource`
+- [ ] Update test properties (use `%test.` prefix in `application.properties`)
+- [ ] Run tests: `mvn test`
+
+## Key Conversions
+
+```java
+// BEFORE: Spring Boot Test
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class TodoControllerTest {
+    @Autowired TestRestTemplate restTemplate;
+    @MockBean TodoService todoService;
+
+    @Test
+    void shouldListTodos() {
+        when(todoService.findAll()).thenReturn(List.of(new Todo("Test")));
+        ResponseEntity<String> response = restTemplate.getForEntity("/todos", String.class);
+        assertEquals(200, response.getStatusCode().value());
+    }
+}
+
+// AFTER: Quarkus Test
+@QuarkusTest
+public class TodoResourceTest {
+    @InjectMock TodoService todoService;
+
+    @Test
+    void shouldListTodos() {
+        when(todoService.findAll()).thenReturn(List.of(new Todo("Test")));
+        given()
+            .when().get("/todos")
+            .then().statusCode(200);
+    }
+}
+```
+
+## Dependencies
+
+Ensure these are in `pom.xml` (should already be added by the build module):
+
+```xml
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-junit5</artifactId>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>io.rest-assured</groupId>
+    <artifactId>rest-assured</artifactId>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-junit5-mockito</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+## Watch out
+
+- **`@InjectMock` package**: Use `io.quarkus.test.InjectMock` (since Quarkus 3.2). The old `io.quarkus.test.junit.mockito.InjectMock` is removed in 4.0.
+- **Test port**: Quarkus tests default to port 8081. If your app uses 8081, set `quarkus.http.test-port=0`.
+- **No `@WebMvcTest` equivalent**: Use `@QuarkusTest` for all test types. For data-only tests, use `@QuarkusTest` with a test profile that disables unneeded extensions.

--- a/skills/migrate-spring-to-quarkus/modules/testing.md
+++ b/skills/migrate-spring-to-quarkus/modules/testing.md
@@ -12,7 +12,7 @@ Load [references/annotation-map.md](../references/annotation-map.md) — see the
 - [ ] Replace `@ActiveProfiles("test")` with `@TestProfile`
 - [ ] Replace `@LocalServerPort` with `@TestHTTPResource`
 - [ ] Update test properties (use `%test.` prefix in `application.properties`)
-- [ ] Run tests: `mvn test` (Maven) or `./gradlew test` (Gradle)
+- [ ] Run tests: `./mvnw test` (Maven) or `./gradlew test` (Gradle)
 
 ## Key Conversions
 

--- a/skills/migrate-spring-to-quarkus/modules/testing.md
+++ b/skills/migrate-spring-to-quarkus/modules/testing.md
@@ -12,7 +12,7 @@ Load [references/annotation-map.md](../references/annotation-map.md) — see the
 - [ ] Replace `@ActiveProfiles("test")` with `@TestProfile`
 - [ ] Replace `@LocalServerPort` with `@TestHTTPResource`
 - [ ] Update test properties (use `%test.` prefix in `application.properties`)
-- [ ] Run tests: `mvn test`
+- [ ] Run tests: `mvn test` (Maven) or `./gradlew test` (Gradle)
 
 ## Key Conversions
 
@@ -49,8 +49,9 @@ public class TodoResourceTest {
 
 ## Dependencies
 
-Ensure these are in `pom.xml` (should already be added by the build module):
+Ensure these are in the build file (should already be added by the build module):
 
+**Maven:**
 ```xml
 <dependency>
     <groupId>io.quarkus</groupId>
@@ -67,6 +68,13 @@ Ensure these are in `pom.xml` (should already be added by the build module):
     <artifactId>quarkus-junit5-mockito</artifactId>
     <scope>test</scope>
 </dependency>
+```
+
+**Gradle:**
+```groovy
+testImplementation 'io.quarkus:quarkus-junit5'
+testImplementation 'io.rest-assured:rest-assured'
+testImplementation 'io.quarkus:quarkus-junit5-mockito'
 ```
 
 ## Watch out

--- a/skills/migrate-spring-to-quarkus/references/annotation-map.md
+++ b/skills/migrate-spring-to-quarkus/references/annotation-map.md
@@ -1,0 +1,189 @@
+# Spring to Quarkus Annotation Map
+
+## Dependency Injection
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-di`) | Notes |
+|---|---|---|---|
+| `@Component` | `@ApplicationScoped` | Supported → `@Singleton` | Compat maps to `@Singleton` by default, not `@ApplicationScoped` |
+| `@Service` | `@ApplicationScoped` | Supported → `@Singleton` | Same as `@Component` in compat |
+| `@Repository` | `@ApplicationScoped` | Supported → `@Singleton` | Same as `@Component` in compat |
+| `@Autowired` | `@Inject` | Supported → `@Inject` | Field, constructor, and setter injection all supported |
+| `@Qualifier("name")` | `@jakarta.inject.Named` or custom `@Qualifier` | Supported → `@Named` | |
+| `@Value("${prop}")` | `@ConfigProperty(name = "prop")` | Supported → `@ConfigProperty` | **SpEL `#{...}` NOT supported** — only `${...}` property placeholders |
+| `@Value("${prop:default}")` | `@ConfigProperty(name = "prop", defaultValue = "default")` | Supported | Inline defaults work |
+| `@Configuration` | `@ApplicationScoped` | Supported → `@ApplicationScoped` | Always application-scoped in compat |
+| `@Bean` | `@Produces` | Supported → `@Produces` | **Must be inside `@Configuration` class** — fails otherwise |
+| `@Primary` | `@io.quarkus.arc.DefaultBean` or `@Alternative` + `@Priority` | **NOT supported** | Not processed by `quarkus-spring-di` |
+| `@Conditional*` | `@IfBuildProfile` or `@LookupIfProperty` | **NOT supported** | Not processed by `quarkus-spring-di` |
+| `@Scope("singleton")` | `@Singleton` | Supported | Default scope for stereotypes |
+| `@Scope("prototype")` | `@Dependent` | Supported | New instance per injection point |
+| `@Scope("request")` | `@RequestScoped` | Supported | Per-HTTP-request lifecycle |
+| `@Scope("session")` | `@SessionScoped` | Supported | Per-session lifecycle |
+| `@Scope("application")` | `@ApplicationScoped` | Supported | Application-wide singleton with proxy |
+| `@Lazy` | No direct equivalent | **NOT supported** | Quarkus beans are lazy by default |
+| `@PostConstruct` | `@PostConstruct` | Works (jakarta.annotation) | Same annotation, no mapping needed |
+| `@PreDestroy` | `@PreDestroy` | Works (jakarta.annotation) | Same annotation, no mapping needed |
+
+**Compat DI notes:**
+- Custom stereotype annotations (meta-annotations extending `@Component`/`@Service`/`@Repository`) are auto-detected
+- `List<T>` injection works: `@Autowired List<MyService>` injects all matching beans
+- `@Named` alone makes a class a bean (becomes `@Singleton`)
+
+## REST / Web
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-web`) | Notes |
+|---|---|---|---|
+| `@RestController` | `@Path` + `@ApplicationScoped` | Supported | Only `@RestController`, **NOT plain `@Controller`** |
+| `@Controller` | `@Path` + `@ApplicationScoped` | **NOT supported** | Compat only supports `@RestController` |
+| `@RequestMapping("/path")` | `@Path("/path")` | Supported | Supports `method`, `produces`, `consumes` attributes |
+| `@GetMapping` | `@GET` | Supported | |
+| `@PostMapping` | `@POST` | Supported | |
+| `@PutMapping` | `@PUT` | Supported | |
+| `@DeleteMapping` | `@DELETE` | Supported | |
+| `@PatchMapping` | `@PATCH` | Supported | |
+| `@PathVariable` | `@PathParam` or `@RestPath` | Supported | Auto-converts types (String, int, Long...) |
+| `@RequestParam` | `@QueryParam` or `@RestQuery` | Supported | `required`, `defaultValue`, `Optional<T>` all work |
+| `@RequestBody` | No annotation needed | Supported | Auto JSON deserialization |
+| `@RequestHeader` | `@HeaderParam` or `@RestHeader` | Supported | |
+| `@CookieValue` | `@CookieParam` or `@RestCookie` | Supported | |
+| `@MatrixVariable` | `@MatrixParam` | Supported | Not commonly used but supported |
+| `@ResponseStatus` | Return `Response` or `RestResponse` | Supported | Works on methods and exception classes |
+| `@ExceptionHandler` | `@ServerExceptionMapper` | Supported (in `@RestControllerAdvice`) | **Only one `@RestControllerAdvice` per app** |
+| `@RestControllerAdvice` | `@ServerExceptionMapper` on a class | Supported | **Limited to one per application** |
+| `@CrossOrigin` | Configure `quarkus.http.cors` in properties | **NOT supported** | Use Quarkus CORS config instead |
+| `@ResponseBody` | Default in Quarkus REST | Implicit | |
+
+**Compat Web notes:**
+- `ResponseEntity<T>` return type is fully supported
+- `ResponseStatusException` can be thrown for error responses
+- Wildcard paths supported: `/api/*`, `/ca?s`, `/api/**`
+- `@RequestParam Map<String, String>` collects all query params
+- `@RequestParam List<String>` splits comma-separated values
+- `@InitBinder`, `@ModelAttribute`, `@SessionAttributes` are **NOT supported**
+
+## Data / JPA
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-data-jpa`) | Notes |
+|---|---|---|---|
+| `@Entity` | `@Entity` | Same | jakarta.persistence — no mapping needed |
+| `@Table` | `@Table` | Same | |
+| `@Id` / `@EmbeddedId` | Same | Same | |
+| `@GeneratedValue` | Same | Same | |
+| `@Transactional` | `jakarta.transaction.Transactional` | Same | **NOT Spring's** `@Transactional` |
+| `@Query("JPQL")` | Panache `find()` / named queries | Supported | Named `:param` and positional `?1` both work. **SpEL `#{...}` NOT supported** |
+| `@Param("name")` | — | Supported | Binds named parameters in `@Query` |
+| `@Modifying` | — | Supported | For UPDATE/DELETE queries; returns void, int, or long |
+| `CrudRepository<T,ID>` | `PanacheRepository<T>` | Supported | |
+| `ListCrudRepository<T,ID>` | `PanacheRepository<T>` | Supported | |
+| `JpaRepository<T,ID>` | `PanacheRepository<T>` | Supported | |
+| `PagingAndSortingRepository<T,ID>` | `PanacheRepository<T>` | Supported | |
+| `ListPagingAndSortingRepository<T,ID>` | `PanacheRepository<T>` | Supported | |
+| `@RepositoryDefinition` | — | Supported | Custom repository without extending interface |
+| `@NoRepositoryBean` | — | Supported | For intermediate base repository interfaces |
+
+**Compat Spring Data JPA notes:**
+- **Derived queries** fully supported: `findBy*`, `countBy*`, `deleteBy*`, `existsBy*`
+- **30+ query keywords**: `Is`, `Not`, `IsNull`, `Between`, `LessThan`, `GreaterThan`, `Like`, `StartingWith`, `EndingWith`, `Containing`, `In`, `NotIn`, `True`, `False`, `IsEmpty`, `IsNotEmpty`, `IgnoreCase`, `OrderBy`, etc.
+- **Top/First** limiting: `findTop3By*`, `findFirstBy*`
+- **Nested property** access: `findByAddress_ZipCode()` traverses relationships
+- **Return types**: `Optional<T>`, `List<T>`, `Set<T>`, `Page<T>`, `Slice<T>`, `Stream<T>`, `Streamable<T>`, `long`, `boolean`
+- **Pagination**: `Pageable` param → `Page<T>` return
+- **Sorting**: `Sort` param supported
+- **Batch operations**: `saveAndFlush()`, `deleteAllInBatch()`, `deleteInBatch()`, `deleteAllByIdInBatch()`
+- **Fragment/mixin pattern**: repositories can extend custom fragment interfaces with implementations
+
+## Scheduling
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-scheduled`) | Notes |
+|---|---|---|---|
+| `@Scheduled(cron=...)` | `@io.quarkus.scheduler.Scheduled(cron=...)` | Supported | Property placeholders `${...}` → `{...}` format |
+| `@Scheduled(fixedRate=1000)` | `@Scheduled(every="1s")` | Supported | Converted to ISO duration |
+| `@Scheduled(fixedDelay=1000)` | `@Scheduled(every="1s")` | **NOT supported** | Throws `IllegalArgumentException` |
+| `@Scheduled(initialDelay=5000)` | `@Scheduled(delay=5000, delayUnit=MILLISECONDS)` | Supported | **Cannot combine with cron** |
+| `@Schedules({...})` | Multiple `@Scheduled` | Supported | Container annotation unwrapped |
+| `@EnableScheduling` | Not needed | Not needed | Auto-enabled with extension |
+| `@Async` | Return `Uni<T>` or `CompletionStage` | **NOT supported** | Use managed executor |
+
+## Security
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-security`) | Notes |
+|---|---|---|---|
+| `@Secured("ROLE_ADMIN")` | `@RolesAllowed("ADMIN")` | Supported | Cannot mix with `@PreAuthorize` on same method |
+| `@PreAuthorize("hasRole('ADMIN')")` | `@RolesAllowed("ADMIN")` | Supported (limited SpEL) | See supported expressions below |
+| `@EnableWebSecurity` | Not needed | Not needed | Configure in `application.properties` |
+| `@AuthenticationPrincipal` | `@Context SecurityContext` or inject `SecurityIdentity` | **NOT supported** | Use Quarkus `SecurityIdentity` |
+
+**Compat `@PreAuthorize` supported expressions:**
+- `permitAll()`, `denyAll()`, `isAuthenticated()`, `isAnonymous()`
+- `hasRole('ROLE')`, `hasAnyRole('R1', 'R2')`
+- `@beanName.methodName()` — bean method returning boolean
+- `#paramName == authentication.principal.username` — compare parameter with current user
+- `#paramName.property == authentication.principal.username` — compare object property
+- `expr1 and expr2`, `expr1 or expr2` — **cannot mix `and` and `or` in same expression**
+- **Full SpEL NOT supported** — only the specific patterns above
+
+## Cache
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-cache`) | Notes |
+|---|---|---|---|
+| `@Cacheable("name")` | `@CacheResult(cacheName = "name")` | Supported | **Single cache name only** — no arrays |
+| `@CacheEvict("name")` | `@CacheInvalidate(cacheName = "name")` | Supported | |
+| `@CacheEvict(value="name", allEntries=true)` | `@CacheInvalidateAll(cacheName = "name")` | Supported | |
+| `@CachePut("name")` | `@CacheInvalidate` + `@CacheResult` | Supported | Invalidates then caches new result |
+| `@Caching(...)` | Combine annotations | **NOT supported** | |
+| `@CacheConfig` | — | **NOT supported** | |
+| `@EnableCaching` | Not needed | Not needed | |
+
+**Compat Cache limitations — these `@Cacheable`/`@CacheEvict` parameters are NOT supported:**
+`key`, `keyGenerator`, `cacheManager`, `cacheResolver`, `condition`, `unless`, `sync`, `beforeInvocation`
+
+## Configuration Properties
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-boot-properties`) | Notes |
+|---|---|---|---|
+| `@ConfigurationProperties(prefix="app")` | `@ConfigMapping(prefix="app")` | Supported | Class-based (with setters) and interface-based |
+| `@ConstructorBinding` | `@ConfigMapping` (record/interface) | **NOT supported** | Compat requires no-arg constructor + setters |
+| `@EnableConfigurationProperties` | Not needed | Not needed | Auto-detected |
+| `@Validated` on config class | `@Valid` | Supported | Auto-validates if Hibernate Validator present |
+
+**Compat `@ConfigurationProperties` notes:**
+- Class-based: requires public class with no-arg constructor and setter methods
+- Interface-based: only getter methods, uses `@ConfigProperty` for custom names
+- Nested objects supported recursively
+- `List<T>`, `Set<T>` supported for primitives/enums
+- `Map<K,V>` **NOT supported** — throws `DeploymentException`
+- Naming: kebab-case by default (`myProperty` → `my-property`)
+
+## Spring Data REST
+
+| Spring | Quarkus (Compat `quarkus-spring-data-rest`) | Notes |
+|---|---|---|
+| `@RepositoryRestResource` | Supported | Auto-generates CRUD endpoints |
+| `@RepositoryRestResource(path="custom")` | Supported | Custom resource path |
+| `@RepositoryRestResource(exported=false)` | Supported | Disables REST exposure |
+| `@RestResource(exported=false)` | Supported | Disables specific method endpoint |
+
+**Auto-generated endpoints**: `GET /`, `GET /{id}`, `POST /`, `PUT /{id}`, `DELETE /{id}` with pagination and sorting.
+
+## Testing
+
+| Spring | Quarkus (Full Migration) | Compat (`quarkus-spring-boot-test`) | Notes |
+|---|---|---|---|
+| `@SpringBootTest` | `@QuarkusTest` | **Supported directly** | Works as Quarkus test annotation |
+| `@WebMvcTest` | `@QuarkusTest` + RestAssured | — | |
+| `@DataJpaTest` | `@QuarkusTest` with test profile | — | |
+| `@MockBean` | `@InjectMock` (`io.quarkus.test.InjectMock`) | — | **Moved in 3.2**: old `io.quarkus.test.junit.mockito.InjectMock` deprecated, removed in 4.0 |
+| `@TestConfiguration` | `@QuarkusTestResource` | — | |
+| `@ActiveProfiles("test")` | `@TestProfile(TestProfile.class)` | — | |
+| `TestRestTemplate` | RestAssured (`given().when().get(...)`) | — | |
+| `@LocalServerPort` | `@TestHTTPResource` | — | |
+
+## Application Lifecycle
+
+| Spring | Quarkus | Notes |
+|---|---|---|
+| `@SpringBootApplication` | No equivalent needed | Quarkus auto-discovers beans |
+| `SpringApplication.run()` | `Quarkus.run()` or just `quarkus:dev` | Usually no main class needed |
+| `CommandLineRunner` | `@Observes StartupEvent` | `io.quarkus.runtime.StartupEvent` |
+| `ApplicationRunner` | `@Observes StartupEvent` | |
+| `@EventListener` | `@Observes` | CDI events |

--- a/skills/migrate-spring-to-quarkus/references/config-map.md
+++ b/skills/migrate-spring-to-quarkus/references/config-map.md
@@ -1,0 +1,146 @@
+# Spring Boot to Quarkus Configuration Map
+
+## Server
+
+| Spring Boot | Quarkus |
+|---|---|
+| `server.port=8080` | `quarkus.http.port=8080` |
+| `server.servlet.context-path=/api` | `quarkus.http.root-path=/api` |
+| `server.ssl.key-store` | `quarkus.http.ssl.certificate.key-store-file` |
+| `server.compression.enabled=true` | `quarkus.http.enable-compression=true` |
+| `server.error.include-message=always` | Configure via exception mappers |
+
+## Datasource
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring.datasource.url` | `quarkus.datasource.jdbc.url` |
+| `spring.datasource.username` | `quarkus.datasource.username` |
+| `spring.datasource.password` | `quarkus.datasource.password` |
+| `spring.datasource.driver-class-name` | `quarkus.datasource.db-kind` (auto-detected) |
+
+## JPA / Hibernate
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring.jpa.hibernate.ddl-auto=update` | `quarkus.hibernate-orm.database.generation=update` |
+| `spring.jpa.show-sql=true` | `quarkus.hibernate-orm.log.sql=true` |
+| `spring.jpa.properties.hibernate.dialect` | `quarkus.hibernate-orm.dialect` (usually auto-detected) |
+| `spring.jpa.properties.hibernate.format_sql` | `quarkus.hibernate-orm.log.format-sql=true` |
+| `spring.jpa.open-in-view=false` | Not applicable (no OSIV in Quarkus) |
+| `spring.jpa.defer-datasource-initialization` | Use Flyway or `import.sql` |
+| `spring.jpa.hibernate.naming.physical-strategy` | `quarkus.hibernate-orm.physical-naming-strategy` |
+| `spring.jpa.hibernate.naming.implicit-strategy` | `quarkus.hibernate-orm.implicit-naming-strategy` |
+
+**Naming strategy warning:** Spring Boot defaults to `SpringPhysicalNamingStrategy` which converts camelCase to snake_case (`firstName` → `first_name`). Quarkus uses Hibernate 6's JPA-compliant default which **preserves Java names as-is** (`firstName` → `firstName`). If your database uses snake_case column names (common with Spring Boot apps), you must either:
+- Set a physical naming strategy: `quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy`
+- Or update `@Column(name="...")` annotations on each entity field
+- **Also update `import.sql` / `data.sql` files** — column names must match the naming strategy
+
+## Flyway
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring.flyway.enabled=true` | `quarkus.flyway.migrate-at-start=true` |
+| `spring.flyway.locations=classpath:db/migration` | `quarkus.flyway.locations=db/migration` |
+| `spring.flyway.baseline-on-migrate=true` | `quarkus.flyway.baseline-on-migrate=true` |
+
+## Logging
+
+| Spring Boot | Quarkus |
+|---|---|
+| `logging.level.root=INFO` | `quarkus.log.level=INFO` |
+| `logging.level.com.example=DEBUG` | `quarkus.log.category."com.example".level=DEBUG` |
+| `logging.file.name=app.log` | `quarkus.log.file.enable=true` + `quarkus.log.file.path=app.log` |
+| `logging.pattern.console` | `quarkus.log.console.format` |
+
+## Profiles
+
+| Spring Boot | Quarkus |
+|---|---|
+| `application-{profile}.properties` | `application-{profile}.properties` (same convention) |
+| `spring.profiles.active=dev` | `quarkus.profile=dev` or `-Dquarkus.profile=dev` |
+| `@Profile("dev")` | `@IfBuildProfile("dev")` |
+| `application-test.properties` | `%test.` prefix in `application.properties`, or `application-test.properties` |
+
+## CORS
+
+| Spring Boot | Quarkus |
+|---|---|
+| `@CrossOrigin` or `WebMvcConfigurer` | `quarkus.http.cors=true` |
+| -- | `quarkus.http.cors.origins=http://localhost:3000` |
+| -- | `quarkus.http.cors.methods=GET,POST,PUT,DELETE` |
+
+## Cache
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring.cache.type=caffeine` | Extension `quarkus-cache` (Caffeine-based by default) |
+| `@Cacheable("name")` | `@io.quarkus.cache.CacheResult(cacheName = "name")` |
+| `@CacheEvict("name")` | `@io.quarkus.cache.CacheInvalidate(cacheName = "name")` |
+
+## Security
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring.security.user.name` | `quarkus.security.users.embedded.users.<name>.password` |
+| `spring.security.oauth2.client.*` | `quarkus.oidc.*` |
+| `spring.security.oauth2.resourceserver.jwt.issuer-uri` | `quarkus.oidc.auth-server-url` |
+
+## Actuator / Health
+
+| Spring Boot | Quarkus |
+|---|---|
+| `management.endpoints.web.exposure.include=*` | Endpoints auto-exposed at `/q/` |
+| `management.endpoint.health.show-details=always` | `quarkus.smallrye-health.ui.always-include=true` |
+| `/actuator/health` | `/q/health` |
+| `/actuator/metrics` | `/q/metrics` |
+| `/actuator/info` | `/q/info` (with `quarkus-info`) |
+
+## Static Resources
+
+| Spring Boot | Quarkus |
+|---|---|
+| `src/main/resources/static/` | `src/main/resources/META-INF/resources/` |
+| `src/main/resources/public/` | `src/main/resources/META-INF/resources/` |
+| `spring.web.resources.static-locations` | Quarkus always uses `META-INF/resources/` |
+
+## Templating (Thymeleaf → Qute)
+
+| Spring Boot (Thymeleaf) | Quarkus (Qute) |
+|---|---|
+| `spring.thymeleaf.prefix=classpath:/templates/` | Templates in `src/main/resources/templates/` (same) |
+| `spring.thymeleaf.cache=false` | Automatic in dev mode |
+| Missing variable → empty string (silent) | Missing variable → **exception** (strict by default) |
+
+**Qute strict rendering** — this is a significant behavior difference:
+
+| Property | Default | Effect |
+|---|---|---|
+| `quarkus.qute.strict-rendering` | `true` | Missing variables throw `TemplateException` at runtime |
+| `quarkus.qute.property-not-found-strategy` | — | Only applies when `strict-rendering=false`: `noop` (empty, like Thymeleaf), `throw-exception`, `output-original` |
+
+**Migration approach:** Start with `strict-rendering=false` and `property-not-found-strategy=output-original` to find all missing variables, then fix them and enable strict mode.
+
+**`@CheckedTemplate`** validates expressions at **build time** — no Thymeleaf equivalent. Use `@CheckedTemplate(requireTypeSafeExpressions = false)` to relax during migration.
+
+## Spring Cloud Config Server
+
+| Spring Boot | Quarkus (`quarkus-spring-cloud-config-client`) |
+|---|---|
+| `spring.cloud.config.uri` | `quarkus.spring-cloud-config.url` (default: `http://localhost:8888`) |
+| `spring.cloud.config.name` | `quarkus.spring-cloud-config.name` |
+| `spring.cloud.config.label` | `quarkus.spring-cloud-config.label` |
+| `spring.cloud.config.username` | `quarkus.spring-cloud-config.username` |
+| `spring.cloud.config.password` | `quarkus.spring-cloud-config.password` |
+| `spring.cloud.config.fail-fast` | `quarkus.spring-cloud-config.fail-fast` (default: false) |
+| `spring.profiles.active` | `quarkus.spring-cloud-config.profiles` |
+
+## Spring Extension Toggle Properties
+
+Each Spring compat extension can be disabled at build time:
+
+| Property | Default | Effect |
+|---|---|---|
+| `quarkus.spring-di.enabled` | `true` | Disable Spring DI annotation processing |
+| `quarkus.spring-cache.enabled` | `true` | Disable Spring Cache annotation processing |

--- a/skills/migrate-spring-to-quarkus/references/config-map.md
+++ b/skills/migrate-spring-to-quarkus/references/config-map.md
@@ -12,12 +12,16 @@
 
 ## Datasource
 
+Use the `%prod.` prefix on datasource properties so that Quarkus Dev Services can automatically provision a database in dev and test modes. Without the prefix, hardcoded connection values override Dev Services in all profiles.
+
+This applies when there are no separate `application-{profile}.properties` files. If profile-specific files exist, place the production datasource config in `application-prod.properties` instead.
+
 | Spring Boot | Quarkus |
 |---|---|
-| `spring.datasource.url` | `quarkus.datasource.jdbc.url` |
-| `spring.datasource.username` | `quarkus.datasource.username` |
-| `spring.datasource.password` | `quarkus.datasource.password` |
-| `spring.datasource.driver-class-name` | `quarkus.datasource.db-kind` (auto-detected) |
+| `spring.datasource.url` | `%prod.quarkus.datasource.jdbc.url` |
+| `spring.datasource.username` | `%prod.quarkus.datasource.username` |
+| `spring.datasource.password` | `%prod.quarkus.datasource.password` |
+| `spring.datasource.driver-class-name` | `quarkus.datasource.db-kind` (auto-detected, no `%prod.` needed) |
 
 ## JPA / Hibernate
 

--- a/skills/migrate-spring-to-quarkus/references/dependency-map.md
+++ b/skills/migrate-spring-to-quarkus/references/dependency-map.md
@@ -1,0 +1,73 @@
+# Spring Boot to Quarkus Dependency Map
+
+## Core
+
+| Spring Boot | Quarkus (Full Migration) | Quarkus (Compatibility) |
+|---|---|---|
+| `spring-boot-starter-web` | `quarkus-rest` | `quarkus-spring-web` |
+| `spring-boot-starter-webflux` | `quarkus-rest` with reactive | `quarkus-spring-web` |
+| `spring-boot-starter-data-jpa` | `quarkus-hibernate-orm-panache` | `quarkus-spring-data-jpa` |
+| `spring-boot-starter-data-rest` | `quarkus-rest` + `quarkus-hibernate-orm-panache` | `quarkus-spring-data-rest` |
+| `spring-boot-starter-validation` | `quarkus-hibernate-validator` | `quarkus-hibernate-validator` |
+| `spring-boot-starter-security` | `quarkus-security` + `quarkus-oidc` (or `quarkus-elytron-security-properties-file`) | `quarkus-spring-security` |
+| `spring-boot-starter-actuator` | `quarkus-smallrye-health` + `quarkus-micrometer` | `quarkus-spring-boot-properties` |
+| `spring-boot-starter-cache` | `quarkus-cache` | `quarkus-spring-cache` |
+| `spring-boot-starter-test` | `quarkus-junit` + `io.rest-assured:rest-assured` | `quarkus-junit` |
+
+## Data / Persistence
+
+| Spring Boot | Quarkus (Full Migration) | Quarkus (Compatibility) |
+|---|---|---|
+| `spring-boot-starter-data-mongodb` | `quarkus-mongodb-panache` | `quarkus-spring-data-api` (limited) |
+| `spring-boot-starter-data-redis` | `quarkus-redis-client` | -- |
+| `spring-boot-starter-jdbc` | `quarkus-agroal` + `quarkus-jdbc-*` | `quarkus-spring-data-jpa` |
+| `h2` (test DB) | `quarkus-jdbc-h2` | `quarkus-jdbc-h2` |
+| `postgresql` | `quarkus-jdbc-postgresql` | `quarkus-jdbc-postgresql` |
+| `mysql-connector-j` | `quarkus-jdbc-mysql` | `quarkus-jdbc-mysql` |
+| `flyway` | `quarkus-flyway` | `quarkus-flyway` |
+| `liquibase` | `quarkus-liquibase` | `quarkus-liquibase` |
+
+## Messaging
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring-boot-starter-amqp` | `quarkus-smallrye-reactive-messaging-amqp` |
+| `spring-kafka` | `quarkus-smallrye-reactive-messaging-kafka` |
+
+## Templating
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring-boot-starter-thymeleaf` | `quarkus-rest-qute` (when controllers return `TemplateInstance`) or `quarkus-qute-web` (auto-serve templates without REST resources). **Never** use `quarkus-qute` alone — it lacks REST integration. |
+| `spring-boot-starter-freemarker` | `quarkus-freemarker` |
+
+## Scheduling / DI / Config
+
+| Spring Boot | Quarkus (Full) | Quarkus (Compat) |
+|---|---|---|
+| `spring-boot-starter` (DI) | `quarkus-arc` (included by default) | `quarkus-spring-di` |
+| `spring-boot-configuration-processor` | `quarkus-arc` (built-in config mapping) | `quarkus-spring-boot-properties` |
+| `spring-boot-starter-quartz` | `quarkus-quartz` or `quarkus-scheduler` | `quarkus-spring-scheduled` |
+
+## Data REST / Cloud / Testing
+
+| Spring Boot | Quarkus (Full) | Quarkus (Compat) |
+|---|---|---|
+| `spring-boot-starter-data-rest` | `quarkus-rest` + `quarkus-hibernate-orm-panache` | `quarkus-spring-data-rest` |
+| `spring-cloud-starter-config` | -- | `quarkus-spring-cloud-config-client` |
+| `spring-boot-starter-test` (with `@SpringBootTest`) | `quarkus-junit` | `quarkus-spring-boot-test` |
+
+## Observability
+
+| Spring Boot | Quarkus |
+|---|---|
+| `micrometer-registry-prometheus` | `quarkus-micrometer-registry-prometheus` |
+| `spring-boot-starter-logging` | `quarkus-logging-json` (JSON) or built-in JBoss Logging |
+| `opentelemetry` | `quarkus-opentelemetry` |
+
+## Build Plugin
+
+| Spring Boot | Quarkus |
+|---|---|
+| `spring-boot-maven-plugin` | `quarkus-maven-plugin` |
+| `spring-boot-gradle-plugin` | `io.quarkus` Gradle plugin |

--- a/skills/migrate-spring-to-quarkus/references/dependency-map.md
+++ b/skills/migrate-spring-to-quarkus/references/dependency-map.md
@@ -71,3 +71,14 @@
 |---|---|
 | `spring-boot-maven-plugin` | `quarkus-maven-plugin` |
 | `spring-boot-gradle-plugin` | `io.quarkus` Gradle plugin |
+
+## Dependency Syntax by Build Tool
+
+Dependencies listed above use Maven artifact coordinates (`groupId:artifactId`). When working with Gradle build files, use the following mapping:
+
+| Maven | Gradle |
+|---|---|
+| `<dependency>` (default scope) | `implementation 'groupId:artifactId'` |
+| `<scope>test</scope>` | `testImplementation 'groupId:artifactId'` |
+| `<scope>runtime</scope>` | `runtimeOnly 'groupId:artifactId'` |
+| `<scope>provided</scope>` | `compileOnly 'groupId:artifactId'` |


### PR DESCRIPTION
This PR adds a Claude Code skill that guides an AI agent through a full Spring Boot to Quarkus migration from reading the codebase to committing the result and opening a draft PR.

The skill is built around a modular, gate-driven approach: instead of running a fixed sequence of steps, it first inspects the project and decides which modules actually apply. Each module (build, code, frontend, testing, cleanup) has an explicit gate condition (ALWAYS, PASS, or SKIP) so the agent only does the work that's relevant to that specific project.

Before starting, the user picks a migration strategy: Spring Compatibility (using quarkus-spring-* extensions, minimal code changes) or Native Quarkus (full replacement with JAX-RS/CDI). The skill adapts all its instructions to the chosen path.

The mapping knowledge lives in three dedicated reference files: dependencies, annotations, and configuration properties that are loaded on demand. 

Each migration run lands in its own branch (migration/run-XX), closes with a structured migration report (including agent name, model, token usage, and estimated cost. The cost is to be improved), and produces a draft PR as a permanent record.

The skill has been tested end-to-end on two real applications: the [spring-boot-todo-app](https://github.com/snowdrop/migration-tool/tree/main/applications/spring-boot-todo-app) and [spring-petclinic](https://github.com/aureamunoz/spring-petclinic.)

                                                       