### PR TITLE
Skill/module to migrate JSP pages to Thymeleaf

### DIFF
--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -39,7 +39,6 @@ Load the relevant reference file when working on a module:
 | [references/annotation-map.md](references/annotation-map.md) | Code module: annotation, DI, REST, Data, Security migration |
 | [references/config-map.md](references/config-map.md) | Build module: configuration property migration |
 
-
 ## Step 1: Analyze & Choose Strategy
 
 Scan the application to understand what needs to migrate:

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -13,6 +13,11 @@ metadata:
 
 Modular, gate-driven migration of Spring Boot applications to Quarkus.
 
+**Migration paths:**
+- **JSP-based apps**: JSP → Thymeleaf (Spring Boot) → Qute (Quarkus)
+- **Thymeleaf-based apps**: Thymeleaf → Qute (Quarkus)
+- **REST APIs**: Direct Spring → Quarkus migration
+
 ## Critical Rules
 
 - **Never delete code you cannot migrate.** If you cannot fully migrate a piece of code, leave the original in place with a `// TODO: Migration required — <reason>` comment explaining what needs to change and why. This applies to:
@@ -42,7 +47,7 @@ Scan the application to understand what needs to migrate:
 - **Build system**: Read the build file (`pom.xml` for Maven, `build.gradle` or `build.gradle.kts` for Gradle) — Spring Boot version, starters, plugins
 - **Java code**: Search for Spring annotations (DI, REST, Data, Security, Scheduling)
 - **Configuration**: Read `application.properties`/`application.yml`, check for profiles
-- **UI / View layer**: Check for Thymeleaf/JSP templates, static resources, Model+View patterns
+- **UI / View layer**: Check for JSP templates in `webapp/WEB-INF/jsp/` or `webapp/WEB-INF/views/`, Thymeleaf templates in `templates/`, static resources, Model+View patterns
 - **Tests**: Check for `@SpringBootTest`, `@WebMvcTest`, `@DataJpaTest`
 
 Present a summary table with area, findings, and complexity. Then ask the user to choose a strategy:
@@ -74,14 +79,15 @@ Inspect the project to determine the gate result — do not rely on blind grep c
 | [jdk](modules/jdk.md)           | JDK 21+ required                                   | **ALWAYS** -- stop migration if < 21 |
 | [build](modules/build.md)       | Spring Boot parent/starters/`spring-boot-maven-plugin` in `pom.xml`, or Spring Boot/`io.spring.dependency-management` plugins in `build.gradle(.kts)` | **PASS** if Spring Boot build markers found; **SKIP** otherwise                          |
 | [code](modules/code.md)         | Spring annotations in Java sources (`@Component`, `@Service`, `@Controller`, `@Repository`, `@Entity`, `@Autowired`, etc.) | **PASS** if Spring annotations found; **SKIP** otherwise                                 |
-| [frontend](modules/frontend.md) | Thymeleaf/JSP templates in `templates/` or static resources in `static/`                                                  | **PASS** if view layer found; **SKIP** otherwise                                         |
+| [frontend-jsp](modules/frontend-jsp.md) | JSP files in `webapp/WEB-INF/jsp/` or `webapp/WEB-INF/views/`, JSP dependencies in pom.xml                                | **PASS** if JSP templates found; **SKIP** otherwise (must run before frontend module)    |
+| [frontend](modules/frontend.md) | Thymeleaf templates in `templates/` or static resources in `static/`                                                  | **PASS** if view layer found; **SKIP** otherwise                                         |
 | [testing](modules/testing.md)   | Spring test annotations in test sources (`@SpringBootTest`, `@WebMvcTest`, `@MockBean`)                                   | **PASS** if Spring tests found; **SKIP** otherwise                                       |
 | [cleanup](modules/cleanup.md)   | Leftover Spring artifacts after all other modules                                                                          | **ALWAYS** — runs after all other modules                                                |
 
 ### Execution Protocol
 
 ```
-FOR module IN [build, code, frontend, testing, cleanup]:
+FOR module IN [build, code, frontend-jsp, frontend, testing, cleanup]:
 
   1. EVALUATE — inspect the project for the gate condition
   2. DECIDE
@@ -100,10 +106,13 @@ FOR module IN [build, code, frontend, testing, cleanup]:
 To run a single module outside the full migration flow, read its file directly:
 
 - "Read `modules/build.md` and execute it"
-- "Run only the frontend module"
+- "Run only the frontend-jsp module" — migrates JSP to Thymeleaf (pre-Quarkus step)
+- "Run only the frontend module" — migrates Thymeleaf to Qute
 - "Re-run the cleanup module"
 
 The module will use the current project state and the chosen strategy (if already decided). If no strategy has been chosen, the module will ask.
+
+**Note:** The `frontend-jsp` module is a pre-migration step that converts JSP pages to Thymeleaf within Spring Boot, before the final Thymeleaf → Qute migration in the `frontend` module.
 
 ## Step 4: Verify the Migration
 

--- a/skills/migrate-spring-to-quarkus/modules/frontend-jsp.md
+++ b/skills/migrate-spring-to-quarkus/modules/frontend-jsp.md
@@ -6,13 +6,13 @@ Migrate JSP pages and tag libraries to Spring MVC + Thymeleaf as an intermediate
 
 - [ ] Add `spring-boot-starter-thymeleaf` dependency to `pom.xml`
 - [ ] Convert JSP files to Thymeleaf `.html` templates
-- [ ] Move templates from `src/main/webapp/WEB-INF/jsp/` to `src/main/resources/templates/`
+- [ ] Move templates from `webapp/WEB-INF/jsp/` to `resources/templates/`
 - [ ] Replace JSTL tags with Thymeleaf expressions
 - [ ] Update controller methods to return logical view names (without `.jsp` extension)
 - [ ] Remove JSP-specific configuration (view resolver, prefix/suffix)
 - [ ] Convert custom tag libraries to Thymeleaf dialects or utility methods
 - [ ] Test rendering in browser
-- [ ] Compile: `mvn clean compile -DskipTests`
+- [ ] Compile: `./mvnw clean compile -DskipTests` or `./gradlew clean compile -x test`
 
 ## Why Migrate from JSP to Thymeleaf?
 
@@ -20,42 +20,40 @@ JSP is not supported in Quarkus. The migration path is: **JSP → Thymeleaf → 
 
 ## Dependency
 
-Add `spring-boot-starter-thymeleaf` starter to `pom.xml`:
+Add `spring-boot-starter-thymeleaf` starter to the project build definition file (`pom.xml` if using Maven, `build.gradle` or `build.gradle.kts` for Gradle).
 
-
-Remove JSP dependencies (if explicitly declared), such as `tomcat-embed-jasper` or `javax.servlet:jstl`.
-
+Remove JSP dependencies (if explicitly declared), such as `jstl` or `jsp-api`.
 
 ## JSP → Thymeleaf Syntax Conversion
 
 | JSP / JSTL | Thymeleaf | Notes |
 |---|---|---|
 | `${name}` | `${name}` or `th:text="${name}"` | Expression in attribute or body |
-| `<c:out value="${name}"/>` | `<span th:text="${name}"/>` | Escaped output |
-| `<c:out value="${html}" escapeXml="false"/>` | `<span th:utext="${html}"/>` | Unescaped HTML |
+| `<c:out value="${name}"/>` | `<span th:text="${name}"></span>` | Escaped output |
+| `<c:out value="${html}" escapeXml="false"/>` | `<span th:utext="${html}"></span>` | Unescaped HTML |
 | `<c:forEach items="${items}" var="item">` | `<div th:each="item : ${items}">` | Loop iteration |
 | `<c:if test="${condition}">` | `<div th:if="${condition}">` | Conditional block |
 | `<c:choose><c:when test="${x}">...<c:otherwise>` | `<div th:if="${x}">...<div th:unless="${x}">` | Conditional switch |
-| `<fmt:formatDate value="${date}" pattern="yyyy-MM-dd"/>` | `<span th:text="${#temporals.format(date, 'yyyy-MM-dd')}"/>` | Date formatting (`java.time` in Spring Boot 3+) |
-| `<fmt:formatNumber value="${price}" pattern="#,##0.00"/>` | `<span th:text="${#numbers.formatDecimal(price, 1, 2)}"/>` | Number formatting |
+| `<fmt:formatDate value="${date}" pattern="yyyy-MM-dd"/>` | `<span th:text="${#temporals.format(date, 'yyyy-MM-dd')}"></span>` | Date formatting (`java.time` in Spring Boot 3+) |
+| `<fmt:formatNumber value="${price}" pattern="#,##0.00"/>` | `<span th:text="${#numbers.formatDecimal(price, 1, 2)}"></span>` | Number formatting |
 | `<c:url value="/path/${id}"/>` | `<a th:href="@{/path/{id}(id=${id})}">` | URL with path variable |
 | `<form action="${pageContext.request.contextPath}/submit">` | `<form th:action="@{/submit}">` | Form action |
-| `<%@ include file="header.jsp" %>` | `<div th:replace="~{fragments/header :: header}"/>` | Static include |
-| `<jsp:include page="header.jsp"/>` | `<div th:insert="~{fragments/header :: header}"/>` | Dynamic include |
+| `<%@ include file="header.jsp" %>` | `<div th:replace="~{fragments/header :: header}"></div>` | Static include |
+| `<jsp:include page="header.jsp"/>` | `<div th:insert="~{fragments/header :: header}"/></div>` | Dynamic include |
 | `${pageContext.request.userPrincipal.name}` | `${#authentication.name}` | Security context (requires `thymeleaf-extras-springsecurity6`) |
 
 ## Template File Location
 
 ```
 # BEFORE (JSP)
-src/main/webapp/WEB-INF/jsp/todos.jsp
-src/main/webapp/WEB-INF/jsp/todo-detail.jsp
-src/main/webapp/WEB-INF/views/error.jsp
+webapp/WEB-INF/jsp/todos.jsp
+webapp/WEB-INF/jsp/todo-detail.jsp
+webapp/WEB-INF/views/error.jsp
 
 # AFTER (Thymeleaf)
-src/main/resources/templates/todos.html
-src/main/resources/templates/todo-detail.html
-src/main/resources/templates/error.html
+resources/templates/todos.html
+resources/templates/todo-detail.html
+resources/templates/error.html
 ```
 
 ## Controller Changes
@@ -102,7 +100,7 @@ Spring Boot auto-configures Thymeleaf when `spring-boot-starter-thymeleaf` is on
 
 ## Static Assets
 
-Static files can remain in `src/main/resources/static/` for Spring Boot. References in templates:
+Static files can remain in `resources/static/` for Spring Boot. References in templates:
 
 **JSP:**
 ```jsp

--- a/skills/migrate-spring-to-quarkus/modules/frontend-jsp.md
+++ b/skills/migrate-spring-to-quarkus/modules/frontend-jsp.md
@@ -1,0 +1,286 @@
+# Module: Frontend / JSP to Thymeleaf Migration
+
+Migrate JSP pages and tag libraries to Spring MVC + Thymeleaf as an intermediate step before Quarkus + Qute migration.
+
+## What to do
+
+- [ ] Add `spring-boot-starter-thymeleaf` dependency to `pom.xml`
+- [ ] Convert JSP files to Thymeleaf `.html` templates
+- [ ] Move templates from `src/main/webapp/WEB-INF/jsp/` to `src/main/resources/templates/`
+- [ ] Replace JSTL tags with Thymeleaf expressions
+- [ ] Update controller methods to return logical view names (without `.jsp` extension)
+- [ ] Remove JSP-specific configuration (view resolver, prefix/suffix)
+- [ ] Convert custom tag libraries to Thymeleaf dialects or utility methods
+- [ ] Test rendering in browser
+- [ ] Compile: `mvn clean compile -DskipTests`
+
+## Why Migrate from JSP to Thymeleaf?
+
+JSP is not supported in Quarkus. The migration path is: **JSP → Thymeleaf → Qute**. Thymeleaf is an intermediate step that allows testing the application in Spring Boot before final Quarkus migration. Reference the [Frontend module](./frontend.md) when performing the migration.
+
+## Dependency
+
+Add `spring-boot-starter-thymeleaf` starter to `pom.xml`:
+
+
+Remove JSP dependencies (if explicitly declared), such as `tomcat-embed-jasper` or `javax.servlet:jstl`.
+
+
+## JSP → Thymeleaf Syntax Conversion
+
+| JSP / JSTL | Thymeleaf | Notes |
+|---|---|---|
+| `${name}` | `${name}` or `th:text="${name}"` | Expression in attribute or body |
+| `<c:out value="${name}"/>` | `<span th:text="${name}"/>` | Escaped output |
+| `<c:out value="${html}" escapeXml="false"/>` | `<span th:utext="${html}"/>` | Unescaped HTML |
+| `<c:forEach items="${items}" var="item">` | `<div th:each="item : ${items}">` | Loop iteration |
+| `<c:if test="${condition}">` | `<div th:if="${condition}">` | Conditional block |
+| `<c:choose><c:when test="${x}">...<c:otherwise>` | `<div th:if="${x}">...<div th:unless="${x}">` | Conditional switch |
+| `<fmt:formatDate value="${date}" pattern="yyyy-MM-dd"/>` | `<span th:text="${#temporals.format(date, 'yyyy-MM-dd')}"/>` | Date formatting (`java.time` in Spring Boot 3+) |
+| `<fmt:formatNumber value="${price}" pattern="#,##0.00"/>` | `<span th:text="${#numbers.formatDecimal(price, 1, 2)}"/>` | Number formatting |
+| `<c:url value="/path/${id}"/>` | `<a th:href="@{/path/{id}(id=${id})}">` | URL with path variable |
+| `<form action="${pageContext.request.contextPath}/submit">` | `<form th:action="@{/submit}">` | Form action |
+| `<%@ include file="header.jsp" %>` | `<div th:replace="~{fragments/header :: header}"/>` | Static include |
+| `<jsp:include page="header.jsp"/>` | `<div th:insert="~{fragments/header :: header}"/>` | Dynamic include |
+| `${pageContext.request.userPrincipal.name}` | `${#authentication.name}` | Security context (requires `thymeleaf-extras-springsecurity6`) |
+
+## Template File Location
+
+```
+# BEFORE (JSP)
+src/main/webapp/WEB-INF/jsp/todos.jsp
+src/main/webapp/WEB-INF/jsp/todo-detail.jsp
+src/main/webapp/WEB-INF/views/error.jsp
+
+# AFTER (Thymeleaf)
+src/main/resources/templates/todos.html
+src/main/resources/templates/todo-detail.html
+src/main/resources/templates/error.html
+```
+
+## Controller Changes
+
+**Before (JSP):**
+
+```java
+@Controller
+public class TodoController {
+    @GetMapping("/todos")
+    public String listTodos(Model model) {
+        model.addAttribute("todos", todoService.findAll());
+        return "todos";  // Resolves to /WEB-INF/jsp/todos.jsp
+    }
+}
+```
+
+**After (Thymeleaf):**
+
+```java
+@Controller
+public class TodoController {
+    @GetMapping("/todos")
+    public String listTodos(Model model) {
+        model.addAttribute("todos", todoService.findAll());
+        return "todos";  // Resolves to templates/todos.html
+    }
+}
+```
+
+Return value stays the same — just the file extension and location change.
+
+## Configuration Changes
+
+**Remove JSP view resolver** from `application.properties`:
+
+```properties
+# DELETE these lines:
+spring.mvc.view.prefix=/WEB-INF/jsp/
+spring.mvc.view.suffix=.jsp
+```
+
+Spring Boot auto-configures Thymeleaf when `spring-boot-starter-thymeleaf` is on the classpath. Default template location is `classpath:/templates/`.
+
+## Static Assets
+
+Static files can remain in `src/main/resources/static/` for Spring Boot. References in templates:
+
+**JSP:**
+```jsp
+<link href="${pageContext.request.contextPath}/css/style.css" rel="stylesheet"/>
+<script src="${pageContext.request.contextPath}/js/app.js"></script>
+```
+
+**Thymeleaf:**
+```html
+<link th:href="@{/css/style.css}" rel="stylesheet"/>
+<script th:src="@{/js/app.js}"></script>
+```
+
+## Form Handling and CSRF
+
+**JSP with Spring Security CSRF:**
+```jsp
+<form action="${pageContext.request.contextPath}/submit" method="post">
+    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+    <!-- fields -->
+</form>
+```
+
+**Thymeleaf (automatic CSRF token injection):**
+```html
+<form th:action="@{/submit}" method="post">
+    <!-- CSRF token automatically added by Spring Security -->
+    <!-- fields -->
+</form>
+```
+
+Thymeleaf automatically adds CSRF tokens to forms when Spring Security is present. No manual token required.
+
+## JSTL Functions → Thymeleaf Utility Objects
+
+| JSTL Function | Thymeleaf Equivalent |
+|---|---|
+| `${fn:length(items)}` | `${#lists.size(items)}` or `${items.size()}` |
+| `${fn:isEmpty(str)}` | `${#strings.isEmpty(str)}` |
+| `${fn:toUpperCase(str)}` | `${#strings.toUpperCase(str)}` |
+| `${fn:substring(str, 0, 5)}` | `${#strings.substring(str, 0, 5)}` |
+| `${fn:contains(str, 'test')}` | `${#strings.contains(str, 'test')}` |
+| `${fn:escapeXml(text)}` | Default behavior in `th:text` |
+
+Full reference: [Thymeleaf Expression Utility Objects](https://www.thymeleaf.org/doc/tutorials/3.1/usingthymeleaf.html#appendix-b-expression-utility-objects)
+
+## Custom Tag Libraries
+
+**JSP custom tags** must be replaced:
+
+1. **Simple formatting tags** → Use Thymeleaf utility objects
+2. **Complex presentation logic** → Extract to `@Component` beans, inject into templates via model
+3. **Reusable fragments** → Use Thymeleaf fragments
+
+**Example: Custom date formatter tag**
+
+```jsp
+<!-- JSP custom tag -->
+<%@ taglib prefix="custom" uri="http://example.com/tags" %>
+<custom:formatDate date="${todo.dueDate}" pattern="long"/>
+```
+
+```java
+// Spring @Component utility
+@Component
+public class DateFormatter {
+    public String formatLong(LocalDate date) {
+        return date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG));
+    }
+}
+```
+
+```java
+// Controller
+@GetMapping("/todos/{id}")
+public String todoDetail(@PathVariable Long id, Model model) {
+    model.addAttribute("todo", todoService.findById(id));
+    model.addAttribute("dateFormatter", dateFormatter);  // Inject utility
+    return "todo-detail";
+}
+```
+
+```html
+<!-- Thymeleaf template -->
+<span th:text="${dateFormatter.formatLong(todo.dueDate)}"/>
+```
+
+Or use `@ControllerAdvice` with `@ModelAttribute` to make utilities globally available:
+
+```java
+@ControllerAdvice
+public class GlobalModelAttributes {
+    @Autowired
+    private DateFormatter dateFormatter;
+    
+    @ModelAttribute("dateFormatter")
+    public DateFormatter dateFormatter() {
+        return dateFormatter;
+    }
+}
+```
+
+## Fragments (Reusable Template Blocks)
+
+**JSP includes:**
+```jsp
+<%@ include file="/WEB-INF/jsp/header.jsp" %>
+```
+
+**Thymeleaf fragments:**
+
+`templates/fragments/header.html`:
+```html
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:fragment="header(title)">
+    <meta charset="UTF-8"/>
+    <title th:text="${title}">Default Title</title>
+    <link th:href="@{/css/style.css}" rel="stylesheet"/>
+</head>
+</html>
+```
+
+Usage in main template:
+```html
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/header :: header('Todo List')}"></head>
+<body>
+    <!-- content -->
+</body>
+</html>
+```
+
+## Template Mode and Doctype
+
+Thymeleaf templates must be valid HTML5:
+
+```html
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title th:text="${title}">Page Title</title>
+</head>
+<body>
+    <!-- content -->
+</body>
+</html>
+```
+
+The `xmlns:th` namespace declaration enables IDE autocomplete but is optional at runtime.
+
+## Common Migration Pitfalls
+
+1. **Forgetting `th:` prefix**: `<div if="${x}">` → **wrong**, must be `th:if`
+2. **Using scriptlets**: JSP `<% %>` has no Thymeleaf equivalent — extract logic to controller/service
+3. **Missing model attributes**: If template references `${user}` but controller doesn't add it, output is often blank/`null`-like; exceptions are more common when dereferencing null values (for example `${user.name}` when `user` is missing).
+4. **Form binding**: Use `th:object` and `th:field` for Spring form binding:
+
+```html
+<form th:action="@{/todos}" th:object="${todoForm}" method="post">
+    <input type="text" th:field="*{title}"/>
+    <input type="date" th:field="*{dueDate}"/>
+    <button type="submit">Save</button>
+</form>
+```
+
+## Testing
+
+1. Start the application: `mvn spring-boot:run`
+2. Open each migrated page in browser
+3. Check for:
+   - Missing attributes (500 errors)
+   - Broken links/forms (404 errors)
+   - Incorrect data rendering
+   - CSRF token issues (403 on POST)
+
+## Next Step
+
+Once JSP → Thymeleaf migration is complete and tested, proceed to **Thymeleaf → Qute migration** using the `frontend.md` module.


### PR DESCRIPTION
Skill updates to migrate JSP pages.

The idea is, if JSP pages are found, migrate them to Thymeleaf early in the process, and then let the existing `frontend` step migrate the new Thymeleaf pages to Qute.

Partially migrates https://github.com/jaygajera17/E-commerce-project-springBoot.

Assisted-By: Claude Code