### PR TITLE
Rename native migration strategy to full Quarkus

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check if a Quarkus project's build files are up-to-date by comparing against ref
 
 ### migrate-spring-to-quarkus
 
-Migrate Spring Boot applications to Quarkus using a modular, gate-driven approach. Supports both Spring compatibility extensions and native Quarkus migration paths. Use this skill when you want to:
+Migrate Spring Boot applications to Quarkus using a modular, gate-driven approach. Supports both Spring compatibility extensions and full Quarkus migration paths. Use this skill when you want to:
 
 - Migrate a Spring Boot application to Quarkus
 - Convert Spring annotations (DI, REST, Data, Security) to Quarkus equivalents

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: migrate-spring-to-quarkus
 description: Migrates Spring Boot applications to Quarkus using a modular, gate-driven approach. 
-  Supports Spring compatibility extensions and native Quarkus migration paths. 
+  Supports Spring compatibility extensions and full Quarkus migration paths. 
   Use when the user wants to migrate, convert, or port a Spring Boot app to Quarkus, mentions "spring to quarkus", 
   "quarkus migration", "replace spring", or asks about migrating "pom.xml", "build.gradle", "Spring MVC", "Spring Data JPA", "Thymeleaf", "@SpringBootApplication".
 license: Apache-2.0
@@ -48,7 +48,7 @@ Scan the application to understand what needs to migrate:
 Present a summary table with area, findings, and complexity. Then ask the user to choose a strategy:
 
 - **Spring compatibility** (recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
-- **Native Quarkus**: Replace all Spring annotations with JAX-RS/CDI. More work, full Quarkus experience.
+- **Full Quarkus**: Replace all Spring annotations with JAX-RS/CDI. More work, full Quarkus experience.
 
 **Stop here and wait for the user's response before continuing.** Do not ask about git workflow or anything else in the same message.
 

--- a/skills/migrate-spring-to-quarkus/modules/code.md
+++ b/skills/migrate-spring-to-quarkus/modules/code.md
@@ -6,10 +6,10 @@ Load [references/annotation-map.md](../references/annotation-map.md) before star
 
 ## What to do
 
-- [ ] Migrate entities (JPA → Panache if native strategy)
-- [ ] Migrate repositories (Spring Data → Panache if native strategy)
+- [ ] Migrate entities (JPA → Panache if full Quarkus strategy)
+- [ ] Migrate repositories (Spring Data → Panache if full Quarkus strategy)
 - [ ] Simplify service layer (remove unnecessary interface+impl)
-- [ ] Migrate controllers/resources (Spring MVC → JAX-RS if native strategy)
+- [ ] Migrate controllers/resources (Spring MVC → JAX-RS if full Quarkus strategy)
 - [ ] Migrate DI annotations (`@Autowired` → `@Inject`, `@Component` → `@ApplicationScoped`, etc.)
 - [ ] Migrate `Model.addAttribute()` → Qute `Template.data()` or `@CheckedTemplate`
 - [ ] Migrate `return "redirect:..."` → `Response.seeOther()`
@@ -18,7 +18,7 @@ Load [references/annotation-map.md](../references/annotation-map.md) before star
 
 Use the annotation-map.md reference for the full mapping. Below are the key patterns with before/after examples.
 
-## Entity Layer (Native strategy)
+## Entity Layer (Full Quarkus strategy)
 
 ```java
 // BEFORE: Spring Data JPA
@@ -41,7 +41,7 @@ public class Todo extends PanacheEntity {
 }
 ```
 
-## Repository Layer (Native strategy)
+## Repository Layer (Full Quarkus strategy)
 
 Two patterns available — choose based on project conventions:
 
@@ -103,7 +103,7 @@ public class TodoService {
 
 **Spring compat strategy**: `@Service` is supported by `quarkus-spring-di` — no changes needed.
 
-## Controller → Resource (Native strategy)
+## Controller → Resource (Full Quarkus strategy)
 
 ```java
 // BEFORE: Spring MVC


### PR DESCRIPTION
Because "native" might be confusing with GraalVM native executables. I think "full" is better name.