### PR TITLE
Produce an empty javadoc JAR for Maven Central compliance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,14 +95,22 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.11.2</version>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.4.2</version>
                         <executions>
                             <execution>
-                                <id>attach-javadocs</id>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.basedir}/src</classesDirectory>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This project has no Java sources, so `maven-javadoc-plugin` logs `No Javadoc in project. Archive not created.` and skips the JAR entirely. Maven Central requires a `-javadoc.jar` artifact, which causes the release to fail at the Sonatype publish step with:

```
Could not publish deployment for 47264bf3-4f66-492e-8ad1-ee5e17bb21d1
```

This replaces `maven-javadoc-plugin` with `maven-jar-plugin` configured to produce an empty `-javadoc` classifier JAR, which satisfies Central's requirements.

See failed run: https://github.com/quarkusio/skills/actions/runs/27519085705