### PR TITLE
 Non-interactive strategy selection

### DIFF
--- a/skills/migrate-spring-to-quarkus/README.md
+++ b/skills/migrate-spring-to-quarkus/README.md
@@ -16,8 +16,8 @@ The skill will analyze your project, ask you to choose a strategy, and execute t
 
 | Strategy | What it does | Best for |
 |---|---|---|
-| **Spring compatibility** (`spring-compat`) | Uses `quarkus-spring-web`, `quarkus-spring-data-jpa`, `quarkus-spring-di`, etc. Minimal code changes. | Teams wanting a low-risk first step, or large codebases where a full rewrite isn't practical yet |
-| **Full Quarkus** (`full-quarkus`) | Replaces all Spring annotations with JAX-RS, CDI, and Panache. Full Quarkus experience. | New projects, small-to-medium apps, or teams ready to fully adopt Quarkus |
+| **Spring compatibility** (`spring-compat`) | Uses `quarkus-spring-web`, `quarkus-spring-data-jpa`, `quarkus-spring-di`, etc. Minimal code changes. | Teams wanting a low-risk first step, reusing their existing Spring code or large codebases where a full migration isn't practical yet |
+| **Full Quarkus** (`full-quarkus`) | Replaces all Spring annotations with JAX-RS, CDI, Hibernate ORM, and Panache. Full Quarkus experience. | New projects, small-to-medium apps, or teams ready to fully adopt Quarkus |
 
 ## Configuration
 
@@ -27,7 +27,7 @@ If you run the skill without any configuration, it will ask you to choose a stra
 
 ### Project config file
 
-Add a `.quarkus-migration.yml` file to your project root to pre-configure the migration:
+Add a `.quarkus-migration.yml` file to your project root to prepare the migration:
 
 ```yaml
 # .quarkus-migration.yml

--- a/skills/migrate-spring-to-quarkus/README.md
+++ b/skills/migrate-spring-to-quarkus/README.md
@@ -1,0 +1,143 @@
+# Spring Boot to Quarkus Migration Skill
+
+Modular, gate-driven migration of Spring Boot applications to Quarkus. Supports both Spring compatibility extensions (`quarkus-spring-*`) and full Quarkus migration paths.
+
+## Quick Start
+
+From your Spring Boot project directory:
+
+```
+Migrate this Spring Boot project to Quarkus
+```
+
+The skill will analyze your project, ask you to choose a strategy, and execute the migration module by module.
+
+## Migration Strategies
+
+| Strategy | What it does | Best for |
+|---|---|---|
+| **Spring compatibility** (`spring-compat`) | Uses `quarkus-spring-web`, `quarkus-spring-data-jpa`, `quarkus-spring-di`, etc. Minimal code changes. | Teams wanting a low-risk first step, or large codebases where a full rewrite isn't practical yet |
+| **Full Quarkus** (`full-quarkus`) | Replaces all Spring annotations with JAX-RS, CDI, and Panache. Full Quarkus experience. | New projects, small-to-medium apps, or teams ready to fully adopt Quarkus |
+
+## Configuration
+
+### Interactive (default)
+
+If you run the skill without any configuration, it will ask you to choose a strategy interactively.
+
+### Project config file
+
+Add a `.quarkus-migration.yml` file to your project root to pre-configure the migration:
+
+```yaml
+# .quarkus-migration.yml
+strategy: spring-compat   # or full-quarkus
+```
+
+When this file is present, the skill skips the strategy prompt and uses the configured value. This is useful for:
+- CI/CD pipelines or automated test runs where no human is present
+- Teams that have already decided on a strategy and don't want to be asked every time
+- Reproducing migrations with consistent settings
+
+### Skill argument
+
+You can also pass the strategy directly when invoking the skill:
+
+```
+Migrate this project to Quarkus using the compatibility migration strategy
+```
+
+### Priority order
+
+If multiple sources provide a strategy, the first match wins:
+
+1. Skill argument (highest priority)
+2. `.quarkus-migration.yml` config file
+3. Interactive prompt (fallback)
+
+## How It Works
+
+The skill follows a 6-step process:
+
+1. **Analyze** — scans your project (build files, Java code, config, templates, tests)
+2. **Choose strategy** — resolved from config or asked interactively
+3. **Execute modules** — runs each migration module through an automatic gate system
+4. **Verify** — 6 post-migration checks (builds, no Spring deps, tests pass, app starts, etc.)
+5. **Review** — self-reflection report with what migrated, what didn't, and why
+6. **Commit** — optional git branch + draft PR workflow
+
+### Gate System
+
+Each module has a gate condition that determines whether it runs:
+
+| Module | Runs when |
+|---|---|
+| **jdk** | Always — stops migration if JDK < 21 |
+| **build** | Spring Boot starters/plugins found in build file |
+| **code** | Spring annotations found in Java sources |
+| **frontend** | Thymeleaf/JSP templates or static resources found |
+| **testing** | Spring test annotations found in test sources |
+| **cleanup** | Always — runs after all other modules |
+
+Modules that don't apply are automatically skipped. After each module, the project is compiled to catch errors before moving on.
+
+## Skill Structure
+
+```
+skills/migrate-spring-to-quarkus/
+├── SKILL.md                          # Main skill instructions (read by the AI agent)
+├── README.md                         # This file (for humans)
+├── modules/                          # Migration modules
+│   ├── jdk.md                        #   JDK version check
+│   ├── build.md                      #   Build file migration (dispatches to Maven or Gradle)
+│   ├── build-maven.md                #   Maven-specific: pom.xml, dependencies, plugins
+│   ├── build-gradle.md               #   Gradle-specific: build.gradle(.kts), plugins
+│   ├── code.md                       #   Java code: annotations, DI, REST, Data, Security
+│   ├── frontend.md                   #   Thymeleaf/JSP templates, static resources
+│   ├── testing.md                    #   Test migration: @SpringBootTest → @QuarkusTest
+│   ├── cleanup.md                    #   Remove leftover Spring artifacts
+│   └── git.md                        #   Git branch and PR workflow
+└── references/                       # Mapping tables loaded during migration
+    ├── dependency-map.md             #   Spring → Quarkus dependency mapping
+    ├── annotation-map.md             #   Spring → Quarkus annotation mapping
+    └── config-map.md                 #   Spring → Quarkus config property mapping
+```
+
+## Running Individual Modules
+
+You can run a single module without executing the full migration:
+
+```
+Run only the build module
+```
+```
+Re-run the frontend module
+```
+
+The module will use the current project state and the chosen strategy (if already decided).
+
+## Post-Migration Checks
+
+After all modules complete, the skill runs 6 verification checks:
+
+| # | Check | Pass criteria |
+|---|---|---|
+| 1 | Builds | `mvn clean package -DskipTests` exits 0 |
+| 2 | No Spring deps | No `org.springframework` in build file (except compat extensions) |
+| 3 | Has Quarkus | Quarkus BOM and at least one extension present |
+| 4 | Tests pass | All tests pass with `@QuarkusTest` |
+| 5 | Starts up | `mvn quarkus:dev` starts, health endpoint returns UP |
+| 6 | No leftover templates | No remaining Thymeleaf/JSP references |
+
+## Git Workflow (optional)
+
+If your project is a git repo, the skill can isolate each migration in its own branch:
+
+- Branch: `migration/run-01`, `migration/run-02`, ...
+- Single commit with all changes + migration report
+- Draft PR against `main` for review (never merged — serves as a permanent diff record)
+
+## Related
+
+- [Quarkus Spring compatibility guides](https://quarkus.io/guides/#spring)
+- [quarkus-update skill](../quarkus-update/) — check and update your Quarkus version

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -45,12 +45,25 @@ Scan the application to understand what needs to migrate:
 - **UI / View layer**: Check for Thymeleaf/JSP templates, static resources, Model+View patterns
 - **Tests**: Check for `@SpringBootTest`, `@WebMvcTest`, `@DataJpaTest`
 
-Present a summary table with area, findings, and complexity. Then ask the user to choose a strategy:
+Present a summary table with area, findings, and complexity. Then choose the migration strategy:
 
-- **Spring compatibility** (recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
-- **Full Quarkus**: Replace all Spring annotations with JAX-RS/CDI. More work, full Quarkus experience.
+### Strategy selection
 
-**Stop here and wait for the user's response before continuing.** Do not ask about git workflow or anything else in the same message.
+Resolve the strategy using the following priority (first match wins):
+
+1. **Skill argument** — if the skill was invoked with a `strategy` argument (`spring-compat` or `full-quarkus`), use it directly.
+2. **Project config file** — check for `.quarkus-migration.yml` in the project root. If it exists and contains a `strategy` field, use that value. Example file:
+   ```yaml
+   # .quarkus-migration.yml
+   strategy: spring-compat   # or full-quarkus
+   ```
+3. **Ask the user** — if neither of the above provided a strategy, ask the user to choose:
+   - **Spring compatibility** (`spring-compat`, recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
+   - **Full Quarkus** (`full-quarkus`): Replace all Spring annotations with JAX-RS/CDI. More work, full Quarkus experience.
+
+   **Stop here and wait for the user's response before continuing.** Do not ask about git workflow or anything else in the same message.
+
+If the strategy was resolved from an argument or config file, log: `Strategy: <value> (source: <argument|config file>)` and continue without asking.
 
 ## Step 2: Git branch (optional)
 


### PR DESCRIPTION
The migration skill now supports pre-configuring the migration strategy via a .quarkus-migration.yml file in the target project root. This allows automated/test environments to skip the interactive prompt without modifying the caller.

  Strategy resolution order:
  1. Skill strategy argument (if provided)
  2. .quarkus-migration.yml in the project root
  3. Interactive prompt (existing behavior, unchanged)