### PR TITLE
Feat/compile fix module

### DIFF
--- a/skills/migrate-spring-to-quarkus/README.md
+++ b/skills/migrate-spring-to-quarkus/README.md
@@ -31,29 +31,38 @@ Add a `.quarkus-migration.yml` file to your project root to prepare the migratio
 
 ```yaml
 # .quarkus-migration.yml
-strategy: spring-compat   # or full-quarkus
+strategy: spring-compat   # spring-compat | full-quarkus
+mode: interactive         # interactive (default) | autonomous
 ```
 
-When this file is present, the skill skips the strategy prompt and uses the configured value. This is useful for:
+When this file is present, the skill skips the strategy prompt and uses the configured values. This is useful for:
 - CI/CD pipelines or automated test runs where no human is present
 - Teams that have already decided on a strategy and don't want to be asked every time
 - Reproducing migrations with consistent settings
 
+#### `mode` values
+
+| Value | Behaviour |
+|---|---|
+| `interactive` (default) | Pauses at decision points and asks the user. On an unfixable file, the agent stops and waits for confirmation before continuing. |
+| `autonomous` | Never pauses. Unfixable files are logged and skipped automatically. All failures are collected and surfaced in the final Migration Report. |
+
 ### Skill argument
 
-You can also pass the strategy directly when invoking the skill:
+You can also pass strategy or mode directly when invoking the skill:
 
 ```
 Migrate this project to Quarkus using the compatibility migration strategy
+Migrate this project to Quarkus autonomously
 ```
 
 ### Priority order
 
-If multiple sources provide a strategy, the first match wins:
+If multiple sources provide a value, the first match wins (applies to both `strategy` and `mode`):
 
 1. Skill argument (highest priority)
 2. `.quarkus-migration.yml` config file
-3. Interactive prompt (fallback)
+3. Default / interactive prompt (fallback)
 
 ## How It Works
 

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -56,6 +56,7 @@ Resolve the strategy using the following priority (first match wins):
    ```yaml
    # .quarkus-migration.yml
    strategy: spring-compat   # or full-quarkus
+   mode: interactive         # interactive (default) | autonomous
    ```
 3. **Ask the user** — if neither of the above provided a strategy, ask the user to choose:
    - **Spring compatibility** (`spring-compat`, recommended): Use `quarkus-spring-web`, `quarkus-spring-data-jpa`, etc. Minimal code changes.
@@ -64,6 +65,21 @@ Resolve the strategy using the following priority (first match wins):
    **Stop here and wait for the user's response before continuing.** Do not ask about git workflow or anything else in the same message.
 
 If the strategy was resolved from an argument or config file, log: `Strategy: <value> (source: <argument|config file>)` and continue without asking.
+
+### Mode selection
+
+Resolve the execution mode using the following priority (first match wins):
+
+1. **Skill argument** — if the skill was invoked with a `mode` argument (`interactive` or `autonomous`), use it directly.
+2. **Project config file** — check `.quarkus-migration.yml` for a `mode` field. Use that value if present.
+3. **Default** — `interactive`.
+
+Log: `Mode: <value> (source: <argument|config file|default>)` and carry this value throughout the migration.
+
+| Mode | Behaviour |
+|---|---|
+| `interactive` | Pauses at decision points and asks the user before continuing. |
+| `autonomous` | Never pauses. On unresolvable failures, logs them and continues. All failures are surfaced in the Migration Report. |
 
 ## Step 2: Git branch (optional)
 
@@ -99,20 +115,20 @@ After the user has chosen a strategy, check if the target project is a git repos
 
 ### Execution Protocol
 
-```
 FOR module IN [build, code, frontend, testing, cleanup]:
 
-  1. EVALUATE — inspect the project for the gate condition
-  2. DECIDE
-     IF gate == ALWAYS → proceed to step 3
-     IF gate == PASS   → proceed to step 3
-     IF gate == SKIP   → log "Module {name}: SKIPPED — {reason}", mark checkbox, continue
-  3. LOAD — read the module file and relevant reference files
-  4. EXECUTE — follow the module instructions, adapting to the chosen strategy
-  5. COMPILE — run the project's compile command (`./mvnw clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle)
-     Fails → follow [compile-fix](modules/compile-fix.md)
-  6. LOG — mark checkbox as done
-```
+1. **EVALUATE** — inspect the project for the gate condition
+2. **DECIDE**
+   - IF gate == ALWAYS → proceed to step 3
+   - IF gate == PASS → proceed to step 3
+   - IF gate == SKIP → log `Module {name}: SKIPPED — {reason}`, mark checkbox, continue
+3. **LOAD** — read the module file and relevant reference files
+4. **EXECUTE** — follow the module instructions, adapting to the chosen strategy
+5. **COMPILE** — run the project's compile command:
+   - Maven: `./mvnw clean compile -DskipTests`
+   - Gradle: `./gradlew clean compileJava -x test`
+   - If compilation fails → follow [compile-fix](modules/compile-fix.md)
+6. **LOG** — mark checkbox as done
 
 ### Running Individual Modules
 
@@ -181,6 +197,10 @@ Present the review as a structured report:
 | Tests pass | PASS/FAIL | |
 | Starts up | PASS/FAIL | |
 | No leftover templates | PASS/FAIL | |
+
+### Compile Fix Failures (MANUAL_REVIEW_REQUIRED)
+| File | Compiler Error | Fixes Attempted |
+|------|---------------|-----------------|
 
 ### Unmigrated Code (TODOs)
 | File | Line | What | Why not migrated |

--- a/skills/migrate-spring-to-quarkus/SKILL.md
+++ b/skills/migrate-spring-to-quarkus/SKILL.md
@@ -110,7 +110,7 @@ FOR module IN [build, code, frontend, testing, cleanup]:
   3. LOAD — read the module file and relevant reference files
   4. EXECUTE — follow the module instructions, adapting to the chosen strategy
   5. COMPILE — run the project's compile command (`./mvnw clean compile -DskipTests` for Maven, `./gradlew clean compileJava -x test` for Gradle)
-     Fails → diagnose and fix before proceeding
+     Fails → follow [compile-fix](modules/compile-fix.md)
   6. LOG — mark checkbox as done
 ```
 

--- a/skills/migrate-spring-to-quarkus/modules/compile-fix.md
+++ b/skills/migrate-spring-to-quarkus/modules/compile-fix.md
@@ -1,0 +1,82 @@
+# Module: Compile Fix
+
+Resolve compilation failures that arise after migrating Spring Boot code to Quarkus.
+
+## Strategy
+
+1. Read the compiler output.
+2. Fix one file at a time.
+3. Recompile after each file fix to verify the change reduced the error count.
+4. Repeat up to **3 attempts per file**.
+5. If a file still fails after 3 attempts → mark it `MANUAL_REVIEW_REQUIRED` (see below), log the error, and ask the user whether to continue with remaining files or stop.
+
+## Common Error Patterns
+
+### Missing or wrong import (`cannot find symbol`, `package does not exist`)
+
+```java
+// BEFORE: Spring / javax
+import javax.persistence.Entity;
+import javax.inject.Inject;
+import org.springframework.stereotype.Service;
+
+// AFTER: Quarkus / jakarta
+import jakarta.persistence.Entity;
+import jakarta.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+```
+
+### Incorrect or unknown annotation (`annotation type not applicable`)
+
+Spring annotations that have no Quarkus equivalent must be replaced. See [references/annotation-map.md](../references/annotation-map.md) for the full table.
+
+Common swaps:
+
+| Spring | Quarkus |
+|---|---|
+| `@Autowired` | `@Inject` |
+| `@Component` / `@Service` / `@Repository` | `@ApplicationScoped` |
+| `@RestController` | `@Path` + `@ApplicationScoped` (full) or keep with `quarkus-spring-web` (compat) |
+| `@Transactional` (Spring) | `@Transactional` (jakarta) |
+
+### Type mismatch (`incompatible types`, `cannot convert`)
+
+Typically caused by return-type changes after repository migration:
+
+```java
+// BEFORE: Spring Data — returns Optional<T>
+Optional<Todo> result = repository.findById(id);
+
+// AFTER: Panache — findById returns T directly (null if not found)
+Todo result = Todo.findById(id);
+```
+
+### Method signature issue (`method not found`, `wrong number of arguments`)
+
+```java
+// BEFORE: Spring Data derived query
+List<Todo> findByCompleted(boolean completed);
+
+// AFTER: Panache
+List<Todo> findByCompleted(boolean completed) {
+    return list("completed", completed);
+}
+```
+
+## MANUAL_REVIEW_REQUIRED
+
+When a file cannot be fixed after 3 attempts, emit:
+
+```
+MANUAL_REVIEW_REQUIRED: <relative/path/to/File.java>
+Reason: <paste the compiler error here>
+Attempted fixes: <brief description of what was tried>
+```
+
+Then ask the user:
+> "I was unable to automatically fix `File.java`. Would you like me to continue migrating the remaining files, or stop here?"
+
+## Watch out
+
+- **Cascading errors**: A single broken class (e.g. a base entity) can produce dozens of errors in subclasses. Fix the root class first.
+- **Jandex index missing**: If CDI beans in an external JAR aren't discovered because the dependency doesn't contain a Jandex index, add `quarkus.index-dependency.<name>.group-id` and, optionally, `quarkus.index-dependency.<name>.artifact-id` to `application.properties`.

--- a/skills/migrate-spring-to-quarkus/modules/compile-fix.md
+++ b/skills/migrate-spring-to-quarkus/modules/compile-fix.md
@@ -8,7 +8,9 @@ Resolve compilation failures that arise after migrating Spring Boot code to Quar
 2. Fix one file at a time.
 3. Recompile after each file fix to verify the change reduced the error count.
 4. Repeat up to **3 attempts per file**.
-5. If a file still fails after 3 attempts → mark it `MANUAL_REVIEW_REQUIRED` (see below), log the error, and ask the user whether to continue with remaining files or stop.
+5. If a file still fails after 3 attempts → emit the `MANUAL_REVIEW_REQUIRED` block (see below), then act according to mode:
+   - **`interactive`** — ask the user: *"I was unable to automatically fix `File.java`. Would you like me to continue migrating the remaining files, or stop here?"* Wait for the response before proceeding.
+   - **`autonomous`** — log the failure internally and continue automatically to the next file. Do **not** pause or ask. All failures will be surfaced in the final Migration Report.
 
 ## Common Error Patterns
 
@@ -65,7 +67,7 @@ List<Todo> findByCompleted(boolean completed) {
 
 ## MANUAL_REVIEW_REQUIRED
 
-When a file cannot be fixed after 3 attempts, emit:
+When a file cannot be fixed after 3 attempts, always emit:
 
 ```
 MANUAL_REVIEW_REQUIRED: <relative/path/to/File.java>
@@ -73,8 +75,7 @@ Reason: <paste the compiler error here>
 Attempted fixes: <brief description of what was tried>
 ```
 
-Then ask the user:
-> "I was unable to automatically fix `File.java`. Would you like me to continue migrating the remaining files, or stop here?"
+Then act according to the current mode (see **Strategy** step 5 above).
 
 ## Watch out
 


### PR DESCRIPTION
Related to: #43 

Changes:
- Added a new compile-fix module that tries to fix each failing file up to 3 times, then prompts the user for feedback if the failure persists
- Added a `mode` configuration property (should take the following values: `interactive` or `autonomous`). When `autonomous` is selected, the agent should not block the migration
- put it in a separate file for reuse (link into other files)

I also added a section on `Common Error Patterns`. If it's too much, I can remove it.