### PR TITLE
 Add smoke tests 

### DIFF
--- a/tests/projects/spring-boot-todo-app/project.yaml
+++ b/tests/projects/spring-boot-todo-app/project.yaml
@@ -10,4 +10,12 @@ checks:
   - tests-pass
   - no-spring-deps
   - has-quarkus
-  - starts-up
+  - smoke-test
+
+endpoints:
+  - path: /
+    method: GET
+    expected_status: 200
+  - path: /home
+    method: GET
+    expected_status: 200

--- a/tests/projects/spring-boot-todo-app/project.yaml
+++ b/tests/projects/spring-boot-todo-app/project.yaml
@@ -6,16 +6,15 @@ source: local
 timeout: 900
 
 checks:
-  - builds
-  - tests-pass
-  - no-spring-deps
-  - has-quarkus
-  - smoke-test
-
-endpoints:
-  - path: /
-    method: GET
-    expected_status: 200
-  - path: /home
-    method: GET
-    expected_status: 200
+  builds:
+  tests-pass:
+  no-spring-deps:
+  has-quarkus:
+  smoke-test:
+    endpoints:
+      - path: /
+        method: GET
+        expected_status: 200
+      - path: /home
+        method: GET
+        expected_status: 200

--- a/tests/projects/spring-jpa-crud/project.yaml
+++ b/tests/projects/spring-jpa-crud/project.yaml
@@ -10,6 +10,7 @@ checks:
   - tests-pass
   - no-spring-deps
   - has-quarkus
+  - starts-up
   - smoke-test
 
 endpoints:

--- a/tests/projects/spring-jpa-crud/project.yaml
+++ b/tests/projects/spring-jpa-crud/project.yaml
@@ -10,4 +10,14 @@ checks:
   - tests-pass
   - no-spring-deps
   - has-quarkus
-  - starts-up
+  - smoke-test
+
+endpoints:
+  - path: /api/todos
+    method: GET
+    expected_status: 200
+  - path: /api/todos
+    method: POST
+    body: '{"title":"Smoke test todo","completed":false}'
+    expected_status: 201
+    body_contains: '"title"'

--- a/tests/projects/spring-jpa-crud/project.yaml
+++ b/tests/projects/spring-jpa-crud/project.yaml
@@ -6,19 +6,17 @@ source: local
 timeout: 600
 
 checks:
-  - builds
-  - tests-pass
-  - no-spring-deps
-  - has-quarkus
-  - starts-up
-  - smoke-test
-
-endpoints:
-  - path: /api/todos
-    method: GET
-    expected_status: 200
-  - path: /api/todos
-    method: POST
-    body: '{"title":"Smoke test todo","completed":false}'
-    expected_status: 201
-    body_contains: '"title"'
+  builds:
+  tests-pass:
+  no-spring-deps:
+  has-quarkus:
+  smoke-test:
+    endpoints:
+      - path: /api/todos
+        method: GET
+        expected_status: 200
+      - path: /api/todos
+        method: POST
+        body: '{"title":"Smoke test todo","completed":false}'
+        expected_status: 201
+        body_contains: '"title"'

--- a/tests/projects/spring-petclinic-rest/project.yaml
+++ b/tests/projects/spring-petclinic-rest/project.yaml
@@ -7,19 +7,18 @@ ref: master
 timeout: 900
 
 checks:
-  - builds
-  - tests-pass
-  - no-spring-deps
-  - has-quarkus
-  - smoke-test
-
-endpoints:
-  - path: /api/owners
-    method: GET
-    expected_status: 200
-  - path: /api/vets
-    method: GET
-    expected_status: 200
-  - path: /api/pettypes
-    method: GET
-    expected_status: 200
+  builds:
+  tests-pass:
+  no-spring-deps:
+  has-quarkus:
+  smoke-test:
+    endpoints:
+      - path: /api/owners
+        method: GET
+        expected_status: 200
+      - path: /api/vets
+        method: GET
+        expected_status: 200
+      - path: /api/pettypes
+        method: GET
+        expected_status: 200

--- a/tests/projects/spring-petclinic-rest/project.yaml
+++ b/tests/projects/spring-petclinic-rest/project.yaml
@@ -11,4 +11,15 @@ checks:
   - tests-pass
   - no-spring-deps
   - has-quarkus
-  - starts-up
+  - smoke-test
+
+endpoints:
+  - path: /api/owners
+    method: GET
+    expected_status: 200
+  - path: /api/vets
+    method: GET
+    expected_status: 200
+  - path: /api/pettypes
+    method: GET
+    expected_status: 200

--- a/tests/projects/spring-rest-api/project.yaml
+++ b/tests/projects/spring-rest-api/project.yaml
@@ -6,19 +6,17 @@ source: local
 timeout: 900
 
 checks:
-  - builds
-  - tests-pass
-  - no-spring-deps
-  - has-quarkus
-  - starts-up
-  - smoke-test
-
-endpoints:
-  - path: /api/greetings
-    method: GET
-    expected_status: 200
-  - path: /api/greetings
-    method: POST
-    body: '{"name":"Test","message":"Hello from smoke test"}'
-    expected_status: 201
-    body_contains: '"name":"Test"'
+  builds:
+  tests-pass:
+  no-spring-deps:
+  has-quarkus:
+  smoke-test:
+    endpoints:
+      - path: /api/greetings
+        method: GET
+        expected_status: 200
+      - path: /api/greetings
+        method: POST
+        body: '{"name":"Test","message":"Hello from smoke test"}'
+        expected_status: 201
+        body_contains: '"name":"Test"'

--- a/tests/projects/spring-rest-api/project.yaml
+++ b/tests/projects/spring-rest-api/project.yaml
@@ -10,6 +10,7 @@ checks:
   - tests-pass
   - no-spring-deps
   - has-quarkus
+  - starts-up
   - smoke-test
 
 endpoints:

--- a/tests/projects/spring-rest-api/project.yaml
+++ b/tests/projects/spring-rest-api/project.yaml
@@ -10,4 +10,14 @@ checks:
   - tests-pass
   - no-spring-deps
   - has-quarkus
-  - starts-up
+  - smoke-test
+
+endpoints:
+  - path: /api/greetings
+    method: GET
+    expected_status: 200
+  - path: /api/greetings
+    method: POST
+    body: '{"name":"Test","message":"Hello from smoke test"}'
+    expected_status: 201
+    body_contains: '"name":"Test"'

--- a/tests/src/test/java/io/quarkus/migration/CheckConfig.java
+++ b/tests/src/test/java/io/quarkus/migration/CheckConfig.java
@@ -1,0 +1,11 @@
+package io.quarkus.migration;
+
+import java.util.List;
+
+public record CheckConfig(
+        List<EndpointCheck> endpoints
+) {
+    public CheckConfig {
+        if (endpoints == null) endpoints = List.of();
+    }
+}

--- a/tests/src/test/java/io/quarkus/migration/EndpointCheck.java
+++ b/tests/src/test/java/io/quarkus/migration/EndpointCheck.java
@@ -1,0 +1,19 @@
+package io.quarkus.migration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record EndpointCheck(
+        String path,
+        String method,
+        String body,
+        @JsonProperty("expected_status") Integer expectedStatus,
+        @JsonProperty("body_contains") String bodyContains
+) {
+    public String effectiveMethod() {
+        return method == null || method.isBlank() ? "GET" : method.toUpperCase();
+    }
+
+    public int effectiveExpectedStatus() {
+        return expectedStatus != null ? expectedStatus : 200;
+    }
+}

--- a/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
@@ -90,6 +90,38 @@ public class MigrationChecks {
             }
             dumpStartupLog(startupLog, "timed out after 60s waiting for HTTP readiness on port " + port);
             return false;
+    /**
+     * Start the app, hit each endpoint defined in project.yaml, and verify responses.
+     * Implicitly verifies startup — projects using this check don't need starts-up separately.
+     */
+    public boolean smokeTest() {
+        if (endpoints.isEmpty()) {
+            System.out.println("      no endpoints defined — skipping");
+            return true;
+        }
+
+        Process process = null;
+        try {
+            process = startApp();
+            if (!waitForReady(process)) {
+                System.out.println("      app failed to start. See " + projectDir.resolve(".startup.log"));
+                return false;
+            }
+
+            boolean allPassed = true;
+            try (HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build()) {
+                for (EndpointCheck ep : endpoints) {
+                    if (!process.isAlive()) {
+                        System.out.println("      app process died mid-test");
+                        return false;
+                    }
+                    boolean ok = testEndpoint(client, ep);
+                    if (!ok) allPassed = false;
+                }
+            }
+            return allPassed;
 
         } catch (Exception e) {
             dumpStartupLog(startupLog, e.getMessage());

--- a/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
@@ -3,7 +3,12 @@ package io.quarkus.migration;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.*;
+import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -11,10 +16,14 @@ import java.util.concurrent.TimeUnit;
  */
 public class MigrationChecks {
 
-    private final Path projectDir;
+    private static final int APP_PORT = 18080;
 
-    public MigrationChecks(Path projectDir) {
+    private final Path projectDir;
+    private final List<EndpointCheck> endpoints;
+
+    public MigrationChecks(Path projectDir, List<EndpointCheck> endpoints) {
         this.projectDir = projectDir;
+        this.endpoints = endpoints != null ? endpoints : List.of();
     }
 
     /**
@@ -133,12 +142,98 @@ public class MigrationChecks {
             case "no-spring-deps" -> noSpringDeps();
             case "has-quarkus" -> hasQuarkus();
             case "starts-up" -> startsUp();
+            case "smoke-test" -> smokeTest();
             case "no-thymeleaf" -> noThymeleaf();
             default -> throw new IllegalArgumentException("Unknown check: " + checkName);
         };
     }
 
-    // -- helpers --
+    // -- app lifecycle helpers --
+
+    private Process startApp() throws IOException {
+        ProcessBuilder pb = new ProcessBuilder(
+                getMvnCmd(), "-q", "quarkus:dev",
+                "-Dquarkus.http.port=" + APP_PORT,
+                "-Dquarkus.devservices.enabled=false",
+                "-Dquarkus.analytics.disabled=true"
+        ).directory(projectDir.toFile())
+         .redirectErrorStream(true)
+         .redirectOutput(projectDir.resolve(".startup.log").toFile());
+
+        return pb.start();
+    }
+
+    private boolean waitForReady(Process process) throws InterruptedException {
+        for (int i = 0; i < 30; i++) {
+            Thread.sleep(2000);
+            if (!process.isAlive()) return false;
+            if (httpOk("http://localhost:" + APP_PORT + "/q/health/ready") ||
+                httpOk("http://localhost:" + APP_PORT + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void stopApp(Process process) {
+        if (process != null) {
+            process.destroyForcibly();
+            try {
+                process.waitFor(10, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
+
+    // -- endpoint testing --
+
+    private boolean testEndpoint(HttpClient client, EndpointCheck ep) {
+        String url = "http://localhost:" + APP_PORT + ep.path();
+        try {
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(10));
+
+            switch (ep.effectiveMethod()) {
+                case "POST" -> reqBuilder
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(ep.body() != null ? ep.body() : ""));
+                case "PUT" -> reqBuilder
+                        .header("Content-Type", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(ep.body() != null ? ep.body() : ""));
+                case "DELETE" -> reqBuilder.DELETE();
+                default -> reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+            int actual = response.statusCode();
+            int expected = ep.effectiveExpectedStatus();
+            boolean statusOk = actual == expected;
+            boolean bodyOk = ep.bodyContains() == null || ep.bodyContains().isBlank()
+                    || response.body().contains(ep.bodyContains());
+
+            if (!statusOk) {
+                System.out.printf("      FAIL %s %s → %d (expected %d)%n",
+                        ep.effectiveMethod(), ep.path(), actual, expected);
+            } else if (!bodyOk) {
+                System.out.printf("      FAIL %s %s → body missing '%s'%n",
+                        ep.effectiveMethod(), ep.path(), ep.bodyContains());
+            } else {
+                System.out.printf("      OK   %s %s → %d%n",
+                        ep.effectiveMethod(), ep.path(), actual);
+            }
+
+            return statusOk && bodyOk;
+
+        } catch (Exception e) {
+            System.out.printf("      FAIL %s %s → %s%n",
+                    ep.effectiveMethod(), ep.path(), e.getMessage());
+            return false;
+        }
+    }
+
+    // -- maven / file helpers --
 
     private int runMaven(String... goals) {
         try {

--- a/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
@@ -19,11 +19,9 @@ public class MigrationChecks {
     private static final int APP_PORT = 18080;
 
     private final Path projectDir;
-    private final List<EndpointCheck> endpoints;
 
-    public MigrationChecks(Path projectDir, List<EndpointCheck> endpoints) {
+    public MigrationChecks(Path projectDir) {
         this.projectDir = projectDir;
-        this.endpoints = endpoints != null ? endpoints : List.of();
     }
 
     /**
@@ -108,10 +106,10 @@ public class MigrationChecks {
 
     /**
      * Start the app, hit each endpoint defined in project.yaml, and verify responses.
-     * Implicitly verifies startup — projects using this check don't need starts-up separately.
+     * Disabling the starts-up check as not needed.
      */
-    public boolean smokeTest() {
-        if (endpoints.isEmpty()) {
+    public boolean smokeTest(List<EndpointCheck> endpoints) {
+        if (endpoints == null || endpoints.isEmpty()) {
             System.out.println("      no endpoints defined — skipping");
             return true;
         }
@@ -177,14 +175,14 @@ public class MigrationChecks {
     /**
      * Run a specific named check.
      */
-    public boolean runCheck(String checkName) {
+    public boolean runCheck(String checkName, CheckConfig checkConfig) {
         return switch (checkName) {
             case "builds" -> builds();
             case "tests-pass" -> testsPass();
             case "no-spring-deps" -> noSpringDeps();
             case "has-quarkus" -> hasQuarkus();
             case "starts-up" -> startsUp();
-            case "smoke-test" -> smokeTest();
+            case "smoke-test" -> smokeTest(checkConfig.endpoints());
             case "no-thymeleaf" -> noThymeleaf();
             default -> throw new IllegalArgumentException("Unknown check: " + checkName);
         };

--- a/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
@@ -90,6 +90,22 @@ public class MigrationChecks {
             }
             dumpStartupLog(startupLog, "timed out after 60s waiting for HTTP readiness on port " + port);
             return false;
+
+        } catch (Exception e) {
+            dumpStartupLog(startupLog, e.getMessage());
+            return false;
+        } finally {
+            if (process != null) {
+                process.descendants().forEach(ProcessHandle::destroyForcibly);
+                process.destroyForcibly();
+                try {
+                    process.waitFor(10, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+    }
+
     /**
      * Start the app, hit each endpoint defined in project.yaml, and verify responses.
      * Implicitly verifies startup — projects using this check don't need starts-up separately.
@@ -100,11 +116,12 @@ public class MigrationChecks {
             return true;
         }
 
+        Path startupLog = projectDir.resolve(".startup.log");
         Process process = null;
         try {
             process = startApp();
             if (!waitForReady(process)) {
-                System.out.println("      app failed to start. See " + projectDir.resolve(".startup.log"));
+                dumpStartupLog(startupLog, "app failed to start");
                 return false;
             }
 
@@ -127,14 +144,7 @@ public class MigrationChecks {
             dumpStartupLog(startupLog, e.getMessage());
             return false;
         } finally {
-            if (process != null) {
-                process.descendants().forEach(ProcessHandle::destroyForcibly);
-                process.destroyForcibly();
-                try {
-                    process.waitFor(10, TimeUnit.SECONDS);
-                } catch (InterruptedException ignored) {
-                }
-            }
+            stopApp(process);
         }
     }
 

--- a/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationChecks.java
@@ -129,7 +129,7 @@ public class MigrationChecks {
                     .build()) {
                 for (EndpointCheck ep : endpoints) {
                     if (!process.isAlive()) {
-                        System.out.println("      app process died mid-test");
+                        System.out.println("      app process crashed. Cannot access the endpoint " + ep.path());
                         return false;
                     }
                     boolean ok = testEndpoint(client, ep);

--- a/tests/src/test/java/io/quarkus/migration/MigrationTest.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationTest.java
@@ -253,7 +253,7 @@ class MigrationTest {
         System.out.println("  provider: " + (provider.isEmpty() ? "(n/a)" : provider));
         System.out.println("  model:    " + model);
         System.out.println("  timeout:  " + aiTimeout() + "s");
-        System.out.println("  checks:   " + (hasChecks ? config.checks() : !aiChecks() ? "disabled (runChecks=false)" : "disabled (none defined)"));
+        System.out.println("  checks:   " + (hasChecks ? config.checks().keySet() : !aiChecks() ? "disabled (runChecks=false)" : "disabled (none defined)"));
         System.out.println("  skills:   " + skills);
         if (totalRuns > 1) {
             System.out.println("  runs:     " + totalRuns + " (per skill)");
@@ -354,16 +354,16 @@ class MigrationTest {
                 // 4. Run checks
                 List<String> failures = new ArrayList<>();
                 if (hasChecks) {
-                    MigrationChecks checks = new MigrationChecks(workDir, config.endpoints());
+                    MigrationChecks checks = new MigrationChecks(workDir);
                     System.out.println("  Running checks...");
 
-                    config.checks().forEach(check -> {
-                        System.out.print("    " + check + " ... ");
-                        boolean passed = checks.runCheck(check);
-                        result.addCheck(check, passed);
+                    config.checks().forEach((checkName, checkConfig) -> {
+                        System.out.print("    " + checkName + " ... ");
+                        boolean passed = checks.runCheck(checkName, checkConfig);
+                        result.addCheck(checkName, passed);
                         System.out.println(passed ? "PASS" : "FAIL");
                         if (!passed) {
-                            failures.add(check);
+                            failures.add(checkName);
                         }
                     });
                 } else {

--- a/tests/src/test/java/io/quarkus/migration/MigrationTest.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationTest.java
@@ -354,7 +354,7 @@ class MigrationTest {
                 // 4. Run checks
                 List<String> failures = new ArrayList<>();
                 if (hasChecks) {
-                    MigrationChecks checks = new MigrationChecks(workDir);
+                    MigrationChecks checks = new MigrationChecks(workDir, config.endpoints());
                     System.out.println("  Running checks...");
 
                     config.checks().forEach(check -> {

--- a/tests/src/test/java/io/quarkus/migration/ProjectConfig.java
+++ b/tests/src/test/java/io/quarkus/migration/ProjectConfig.java
@@ -13,6 +13,8 @@ public record ProjectConfig(
         String source,
         String ref,
         int timeout,
+        List<String> checks,
+        List<EndpointCheck> endpoints
         TestConfig test,
         List<String> checks
 ) {

--- a/tests/src/test/java/io/quarkus/migration/ProjectConfig.java
+++ b/tests/src/test/java/io/quarkus/migration/ProjectConfig.java
@@ -14,9 +14,8 @@ public record ProjectConfig(
         String ref,
         int timeout,
         List<String> checks,
-        List<EndpointCheck> endpoints
         TestConfig test,
-        List<String> checks
+        List<EndpointCheck> endpoints
 ) {
     public record TestConfig(Boolean enabled) {
         public TestConfig {

--- a/tests/src/test/java/io/quarkus/migration/ProjectConfig.java
+++ b/tests/src/test/java/io/quarkus/migration/ProjectConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.migration;
 
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Maps to a project.yaml file defining a test project.
@@ -13,14 +14,20 @@ public record ProjectConfig(
         String source,
         String ref,
         int timeout,
-        List<String> checks,
-        TestConfig test,
-        List<EndpointCheck> endpoints
+        Map<String, CheckConfig> checks,
+        TestConfig test
 ) {
     public record TestConfig(Boolean enabled) {
         public TestConfig {
             if (enabled == null) enabled = true;
         }
+    }
+
+    public Map<String, CheckConfig> checks() {
+        if (checks == null) return Map.of();
+        var normalized = new LinkedHashMap<String, CheckConfig>();
+        checks.forEach((k, v) -> normalized.put(k, v == null ? new CheckConfig(null) : v));
+        return normalized;
     }
 
     public boolean isTestEnabled() {


### PR DESCRIPTION
- Extract app start/stop logic into reusable helpers (startApp, waitForReady, stopApp)                                                                                                                  
- Add smoke-test check: starts the app, waits for readiness, and tests each endpoint defined in project.yaml using java.net.http.HttpClient (GET/POST/PUT/DELETE, status code + optional body verification)                                                                                                                                                                                           
- Register smoke-test in runCheck(), add EndpointCheck record and endpoints field to ProjectConfig                                                                                                      
- Replace starts-up with smoke-test in spring-rest-api and spring-jpa-crud project.yaml files                                                                                                           

Validated with pi agent on spring-rest-api: 5/5 checks, smoke-test OK (GET + POST).

 What's left                                                                                                                                                                                         
                                                                                                                                                                                                          
  - [x] Add endpoints and smoke-test check to the remaining project.yaml files (spring-jpa-crud already done, pending: spring-boot-todo-app, spring-petclinic, spring-petclinic-rest)                                                                                                                                                           
  - [ ] Once PR #36 (ClaudeRunner) is merged, run the same projects with claude and compare token usage, cost, and duration against pi/opencode       