### PR TITLE
Rename Global Summary name to Benchmark report

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -227,7 +227,7 @@ mvn test \
 
 ## Benchmark: comparing skills
 
-Use `-Dai.skills` to benchmark up to 2 skills against one or more projects. Each skill is run independently with its own set of runs, and a global summary report with delta comparison is generated at the end.
+Use `-Dai.skills` to benchmark up to 2 skills against one or more projects. Each skill is run independently with its own set of runs, and a benchmark summary report with delta comparison is generated at the end.
 
 ### Single project, 2 skills
 
@@ -266,9 +266,9 @@ mvn test \
 When benchmarking with 2 skills, the harness generates:
 
 - **Per-skill summary** (`target/runs/<project>_<skill>_*.summary.md`) — averages across runs for each skill+project combination
-- **Global summary** (`target/runs/global.summary.md`) — side-by-side comparison with a delta row showing the percentage difference between the two skills
+- **Benchmark summary** (`target/runs/beanchmark-report.md`) — side-by-side comparison with a delta row showing the percentage difference between the two skills for tokens, tools, etc
 
-Example global summary output:
+Example of benchmark output:
 
 ```
 | Skill | mtool? | Runs | Avg Duration | Avg Input | Avg Output | Avg Cache Read | Avg Total Tokens | Avg Cost |

--- a/tests/README.md
+++ b/tests/README.md
@@ -266,7 +266,7 @@ mvn test \
 When benchmarking with 2 skills, the harness generates:
 
 - **Per-skill summary** (`target/runs/<project>_<skill>_*.summary.md`) — averages across runs for each skill+project combination
-- **Benchmark summary** (`target/runs/beanchmark-report.md`) — side-by-side comparison with a delta row showing the percentage difference between the two skills for tokens, tools, etc
+- **Benchmark summary** (`target/runs/benchmark-report.md`) — side-by-side comparison with a delta row showing the percentage difference between the two skills for tokens, tools, etc
 
 Example of benchmark output:
 

--- a/tests/src/test/java/io/quarkus/migration/MigrationTest.java
+++ b/tests/src/test/java/io/quarkus/migration/MigrationTest.java
@@ -222,7 +222,7 @@ class MigrationTest {
         }
     }
 
-    private static final Map<String, List<MigrationResult>> globalResultsBySkill = new LinkedHashMap<>();
+    private static final Map<String, List<MigrationResult>> skillsComparisonResults = new LinkedHashMap<>();
 
     // -- the actual test --
 
@@ -296,7 +296,7 @@ class MigrationTest {
                 System.out.println("=".repeat(60));
             }
 
-            List<MigrationResult> skillResults = new ArrayList<>();
+            List<MigrationResult> skillResultRuns = new ArrayList<>();
 
             for (int run = 1; run <= totalRuns; run++) {
                 String runName = totalRuns > 1 ? baseRunName + "_run" + run : baseRunName;
@@ -386,20 +386,20 @@ class MigrationTest {
 
                 // 6. Record result
                 tracker.record(result);
-                skillResults.add(result);
+                skillResultRuns.add(result);
                 System.out.println("\n" + result);
 
                 lastFailures = failures;
                 lastScore = result.score();
             }
 
-            // 7. Write per-skill summary when multiple runs
+            // 7. Write per-skill report when multiple runs have been executed
             if (totalRuns > 1) {
-                tracker.writeSummaryReport(skillResults, baseRunName);
+                tracker.writeSkillSummaryReport(skillResultRuns, baseRunName);
             }
 
-            // Collect for global summary
-            globalResultsBySkill.computeIfAbsent(skillRefStr, k -> new ArrayList<>()).addAll(skillResults);
+            // Collect skillResultRuns about the Skills compared (max 2) for the benchmark report
+            skillsComparisonResults.computeIfAbsent(skillRefStr, k -> new ArrayList<>()).addAll(skillResultRuns);
         }
 
         // 8. Assert last run's checks passed (skip in benchmark mode to collect all results)
@@ -411,16 +411,16 @@ class MigrationTest {
     }
 
     @AfterAll
-    static void generateGlobalSummary() {
-        boolean multipleSkills = globalResultsBySkill.size() > 1;
-        boolean multipleProjects = globalResultsBySkill.values().stream()
+    static void generateBenchmarkReport() {
+        boolean multipleSkills = skillsComparisonResults.size() > 1;
+        boolean multipleProjects = skillsComparisonResults.values().stream()
                 .flatMap(List::stream)
                 .map(MigrationResult::getProject)
                 .distinct()
                 .count() > 1;
 
         if (multipleSkills || multipleProjects) {
-            tracker.writeGlobalSummary(globalResultsBySkill);
+            tracker.writeBenchmarkComparisonReport(skillsComparisonResults);
         }
     }
 

--- a/tests/src/test/java/io/quarkus/migration/ResultsTracker.java
+++ b/tests/src/test/java/io/quarkus/migration/ResultsTracker.java
@@ -230,10 +230,83 @@ public class ResultsTracker {
         }
     }
 
-    public void writeSummaryReport(List<MigrationResult> results, String baseRunName) {
+
+    public void writeBenchmarkComparisonReport(Map<String, List<MigrationResult>> resultsBySkill) {
+        List<String> skillNames = new ArrayList<>(resultsBySkill.keySet());
+        String titleSkills = String.join(" vs ", skillNames);
+        Path summaryFile = historyFile.getParent().resolve("benchmark-report.md");
+
+        var sb = new StringBuilder();
+        sb.append("# Benchmark report and comparison: %s\n\n".formatted(titleSkills));
+
+        sb.append("## Global Summary\n\n");
+        sb.append("| Skill | Runs | Avg Duration | Avg Tool calls | Avg Input | Avg Output | Avg Cache Read | Avg Cache Write | Avg Total Tokens | Avg Cost | Avg $/MTokens |\n");
+        sb.append("|---|---|---|---|---|---|---|---|---|---|---|\n");
+
+        var skillAvgs = new ArrayList<double[]>();
+
+        for (var entry : resultsBySkill.entrySet()) {
+            String skillName = entry.getKey();
+            List<MigrationResult> results = entry.getValue();
+            int runs = results.size();
+
+            double[] durations = results.stream().mapToDouble(r -> r.getDuration().toSeconds()).toArray();
+            double[] gTools = results.stream().mapToDouble(MigrationResult::getToolCalls).toArray();
+            double[] inputs = results.stream().mapToDouble(MigrationResult::getInputTokens).toArray();
+            double[] outputs = results.stream().mapToDouble(MigrationResult::getOutputTokens).toArray();
+            double[] cacheReads = results.stream().mapToDouble(MigrationResult::getCacheRead).toArray();
+            double[] cacheWrites = results.stream().mapToDouble(MigrationResult::getCacheWrite).toArray();
+            double[] totals = results.stream().mapToDouble(MigrationResult::getTotalTokens).toArray();
+            double[] costs = results.stream().mapToDouble(MigrationResult::getTotalCost).toArray();
+            double[] gRates = results.stream().mapToDouble(r ->
+                    r.getTotalTokens() > 0 ? r.getTotalCost() / r.getTotalTokens() * 1_000_000 : 0).toArray();
+
+            sb.append("| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n".formatted(
+                    skillName, runs,
+                    formatDurationWithStddev(durations),
+                    formatIntWithStddev(gTools),
+                    formatTokensWithStddev(inputs), formatTokensWithStddev(outputs),
+                    formatTokensWithStddev(cacheReads), formatTokensWithStddev(cacheWrites),
+                    formatTokensWithStddev(totals), formatCostWithStddev(costs),
+                    formatRateWithStddev(gRates)));
+
+            skillAvgs.add(new double[]{
+                    mean(durations), mean(gTools), mean(inputs), mean(outputs),
+                    mean(cacheReads), mean(cacheWrites), mean(totals), mean(costs),
+                    mean(gRates)
+            });
+        }
+
+        if (resultsBySkill.size() == 2) {
+            double[] a = skillAvgs.get(0);
+            double[] b = skillAvgs.get(1);
+
+            sb.append("| **Delta** | — ");
+            for (int i = 0; i < a.length; i++) {
+                if (a[i] == 0) {
+                    sb.append("| — ");
+                } else {
+                    double pct = (b[i] - a[i]) / a[i] * 100;
+                    sb.append(String.format(Locale.US, "| %+.1f%% ", pct));
+                }
+            }
+            sb.append("|\n");
+        }
+
+        sb.append("\n");
+
+        try {
+            Files.writeString(summaryFile, sb.toString());
+            System.out.println("  Global summary: " + summaryFile);
+        } catch (IOException e) {
+            System.err.println("Failed to write global summary: " + e.getMessage());
+        }
+    }
+
+    public void writeSkillSummaryReport(List<MigrationResult> results, String baseRunName) {
         if (results == null || results.isEmpty()) return;
 
-        Path summaryFile = historyFile.getParent().resolve(baseRunName + ".summary.md");
+        Path summaryFile = historyFile.getParent().resolve(baseRunName + "-report.md");
         int n = results.size();
 
         double[] durations = results.stream().mapToDouble(r -> r.getDuration().toSeconds()).toArray();
@@ -366,79 +439,4 @@ public class ResultsTracker {
         return String.valueOf(n);
     }
 
-    public void writeGlobalSummary(Map<String, List<MigrationResult>> resultsBySkill) {
-        List<String> skillNames = new ArrayList<>(resultsBySkill.keySet());
-        String titleSkills = String.join(" vs ", skillNames);
-        Path summaryFile = historyFile.getParent().resolve("global.summary.md");
-
-        var sb = new StringBuilder();
-        sb.append("# Report benchmark and comparison: %s\n\n".formatted(titleSkills));
-
-        sb.append("## Global Summary\n\n");
-        sb.append("| Skill | Runs | Avg Duration | Avg Tool calls | Avg Input | Avg Output | Avg Cache Read | Avg Cache Write | Avg Total Tokens | Avg Cost | Avg $/MTokens |\n");
-        sb.append("|---|---|---|---|---|---|---|---|---|---|---|\n");
-
-        var skillAvgs = new ArrayList<double[]>();
-
-        for (var entry : resultsBySkill.entrySet()) {
-            String skillName = entry.getKey();
-            List<MigrationResult> results = entry.getValue();
-            int runs = results.size();
-
-            double[] durations = results.stream().mapToDouble(r -> r.getDuration().toSeconds()).toArray();
-            double[] gTools = results.stream().mapToDouble(MigrationResult::getToolCalls).toArray();
-            double[] inputs = results.stream().mapToDouble(MigrationResult::getInputTokens).toArray();
-            double[] outputs = results.stream().mapToDouble(MigrationResult::getOutputTokens).toArray();
-            double[] cacheReads = results.stream().mapToDouble(MigrationResult::getCacheRead).toArray();
-            double[] cacheWrites = results.stream().mapToDouble(MigrationResult::getCacheWrite).toArray();
-            double[] totals = results.stream().mapToDouble(MigrationResult::getTotalTokens).toArray();
-            double[] costs = results.stream().mapToDouble(MigrationResult::getTotalCost).toArray();
-            double[] gRates = results.stream().mapToDouble(r ->
-                    r.getTotalTokens() > 0 ? r.getTotalCost() / r.getTotalTokens() * 1_000_000 : 0).toArray();
-
-            sb.append("| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n".formatted(
-                    skillName, runs,
-                    formatDurationWithStddev(durations),
-                    formatIntWithStddev(gTools),
-                    formatTokensWithStddev(inputs), formatTokensWithStddev(outputs),
-                    formatTokensWithStddev(cacheReads), formatTokensWithStddev(cacheWrites),
-                    formatTokensWithStddev(totals), formatCostWithStddev(costs),
-                    formatRateWithStddev(gRates)));
-
-            skillAvgs.add(new double[]{
-                    mean(durations), mean(gTools), mean(inputs), mean(outputs),
-                    mean(cacheReads), mean(cacheWrites), mean(totals), mean(costs),
-                    mean(gRates)
-            });
-        }
-
-        if (resultsBySkill.size() == 2) {
-            double[] a = skillAvgs.get(0);
-            double[] b = skillAvgs.get(1);
-
-            sb.append("| **Delta** | — ");
-            for (int i = 0; i < a.length; i++) {
-                if (a[i] == 0) {
-                    sb.append("| — ");
-                } else {
-                    double pct = (b[i] - a[i]) / a[i] * 100;
-                    sb.append(String.format(Locale.US, "| %+.1f%% ", pct));
-                }
-            }
-            sb.append("|\n");
-        }
-
-        sb.append("\n");
-
-        try {
-            Files.writeString(summaryFile, sb.toString());
-            System.out.println("  Global summary: " + summaryFile);
-        } catch (IOException e) {
-            System.err.println("Failed to write global summary: " + e.getMessage());
-        }
-    }
-
-    public Path getHistoryFile() {
-        return historyFile;
-    }
 }

--- a/tests/src/test/java/io/quarkus/migration/ResultsTracker.java
+++ b/tests/src/test/java/io/quarkus/migration/ResultsTracker.java
@@ -299,7 +299,7 @@ public class ResultsTracker {
             Files.writeString(summaryFile, sb.toString());
             System.out.println("  Benchmark report: " + summaryFile);
         } catch (IOException e) {
-            System.err.println("Failed to write global summary: " + e.getMessage());
+            System.err.println("Failed to write benchmark report: " + e.getMessage());
         }
     }
 

--- a/tests/src/test/java/io/quarkus/migration/ResultsTracker.java
+++ b/tests/src/test/java/io/quarkus/migration/ResultsTracker.java
@@ -297,7 +297,7 @@ public class ResultsTracker {
 
         try {
             Files.writeString(summaryFile, sb.toString());
-            System.out.println("  Global summary: " + summaryFile);
+            System.out.println("  Benchmark report: " + summaryFile);
         } catch (IOException e) {
             System.err.println("Failed to write global summary: " + e.getMessage());
         }

--- a/tests/src/test/java/io/quarkus/migration/test/BenchmarkReportTest.java
+++ b/tests/src/test/java/io/quarkus/migration/test/BenchmarkReportTest.java
@@ -16,79 +16,16 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Validates the summary and global summary report generation:
- * averages, stddev, delta percentages, and the end-to-end pipeline
- * from JSONL fixture files to global.summary.md.
+ * Validates the benchmark report content
  */
-class SummaryReportTest {
+class BenchmarkReportTest {
 
     @TempDir
     Path tempDir;
 
-    // ─── Summary report (writeSummaryReport) ──────────────────────────
-
     @Test
-    @DisplayName("writeSummaryReport computes correct averages and stddev for multiple runs")
-    void writeSummaryReportAvgStddev() throws IOException {
-        Path historyFile = tempDir.resolve("history.jsonl");
-        ResultsTracker tracker = new ResultsTracker(historyFile);
-
-        MigrationResult r1 = buildResult("dummy", "claude-opus-4-6", "run1");
-        r1.setDuration(Duration.ofSeconds(60));
-        r1.setTotalTokens(70_000);
-        r1.setTotalCost(0.50);
-        r1.setInputTokens(800);
-        r1.setOutputTokens(500);
-        r1.setCacheRead(45_000);
-        r1.setCacheWrite(23_700);
-
-        MigrationResult r2 = buildResult("dummy", "claude-opus-4-6", "run2");
-        r2.setDuration(Duration.ofSeconds(80));
-        r2.setTotalTokens(80_000);
-        r2.setTotalCost(0.70);
-        r2.setInputTokens(1000);
-        r2.setOutputTokens(600);
-        r2.setCacheRead(55_000);
-        r2.setCacheWrite(23_400);
-
-        tracker.writeSummaryReport(List.of(r1, r2), "summary-base");
-
-        String summary = Files.readString(tempDir.resolve("summary-base.summary.md"));
-
-        // Avg duration = 70s => 1m 10s, stddev = 10s
-        assertContains(summary, "1m 10s (+/- 10s)");
-
-        // Avg cost = $0.60, stddev = $0.10
-        assertContains(summary, "$0.60 (+/- $0.10)");
-
-        // Avg total tokens = 75,000, stddev = 5,000
-        assertContains(summary, "75,000 (+/- 5,000)");
-    }
-
-    @Test
-    @DisplayName("writeSummaryReport with single run has zero stddev")
-    void writeSummaryReportSingleRun() throws IOException {
-        Path historyFile = tempDir.resolve("history.jsonl");
-        ResultsTracker tracker = new ResultsTracker(historyFile);
-
-        MigrationResult r = buildResult("dummy", "claude-opus-4-6", "solo");
-        r.setDuration(Duration.ofSeconds(28));
-        r.setTotalTokens(75_241);
-        r.setTotalCost(0.195412);
-
-        tracker.writeSummaryReport(List.of(r), "solo-base");
-
-        String summary = Files.readString(tempDir.resolve("solo-base.summary.md"));
-
-        assertContains(summary, "0m 28s (+/- 0s)");
-        assertContains(summary, "$0.20 (+/- $0.00)");
-    }
-
-    // ─── Global summary (writeGlobalSummary) ──────────────────────────
-
-    @Test
-    @DisplayName("writeGlobalSummary computes delta percentages between two skills")
-    void writeGlobalSummaryDelta() throws IOException {
+    @DisplayName("writeBenchmarkReportAndCheckDelta creates a benchmark report and computes delta between two skills compared")
+    void writeBenchmarkReportAndCheckDelta() throws IOException {
         Path historyFile = tempDir.resolve("history.jsonl");
         ResultsTracker tracker = new ResultsTracker(historyFile);
 
@@ -114,25 +51,25 @@ class SummaryReportTest {
         bySkill.put("skills/skill-a", List.of(rA));
         bySkill.put("skills/skill-b", List.of(rB));
 
-        tracker.writeGlobalSummary(bySkill);
+        tracker.writeBenchmarkComparisonReport(bySkill);
 
-        String global = Files.readString(tempDir.resolve("global.summary.md"));
-        assertContains(global, "# Report benchmark and comparison:");
-        assertContains(global, "| **Delta** |");
+        String benchmark = Files.readString(tempDir.resolve("benchmark-report.md"));
+        assertContains(benchmark, "# Benchmark report and comparison:");
+        assertContains(benchmark, "| **Delta** |");
 
         // Duration delta: (78-66)/66 * 100 = +18.2%
-        assertContains(global, "+18.2%");
+        assertContains(benchmark, "+18.2%");
 
         // Total tokens delta: (446433-240654)/240654 * 100 = +85.5%
-        assertContains(global, "+85.5%");
+        assertContains(benchmark, "+85.5%");
 
         // Cost delta: (0.86-0.50)/0.50 * 100 = +72.0%
-        assertContains(global, "+72.0%");
+        assertContains(benchmark, "+72.0%");
     }
 
     @Test
-    @DisplayName("writeGlobalSummary with single skill produces no delta row")
-    void writeGlobalSummaryNoDelta() throws IOException {
+    @DisplayName("writeBenchmark with single skill produces no delta row")
+    void writeBenchmarkTestWithNoDelta() throws IOException {
         Path historyFile = tempDir.resolve("history.jsonl");
         ResultsTracker tracker = new ResultsTracker(historyFile);
 
@@ -141,18 +78,18 @@ class SummaryReportTest {
         r.setTotalTokens(240_654);
         r.setTotalCost(0.50);
 
-        Map<String, List<MigrationResult>> bySkill = Map.of("only-skill", List.of(r));
-        tracker.writeGlobalSummary(bySkill);
+        Map<String, List<MigrationResult>> bySkill = Map.of("single-skill", List.of(r));
+        tracker.writeBenchmarkComparisonReport(bySkill);
 
-        String global = Files.readString(tempDir.resolve("global.summary.md"));
+        String global = Files.readString(tempDir.resolve("benchmark-report.md"));
         assertFalse(global.contains("**Delta**"), "single-skill summary should not have a delta row");
     }
 
-    // ─── Global summary from fixture JSONL files ──────────────────────
+    // ─── Benchmark from fixture JSONL files ──────────────────────
 
     @Test
-    @DisplayName("end-to-end: two fixture sessions produce correct global.summary.md with delta")
-    void globalSummaryFromFixtures() throws IOException {
+    @DisplayName("end-to-end: two fixture sessions produce correct benchmark-report.md with delta")
+    void EndToEndTestFromFixtures() throws IOException {
         Path fixture1 = tempDir.resolve("session1.jsonl");
         Path fixture2 = tempDir.resolve("session2.jsonl");
         try (var in1 = getClass().getResourceAsStream("/sessions/dummy1_claude_session.jsonl");
@@ -199,33 +136,33 @@ class SummaryReportTest {
         MigrationResult rB = buildResultFromStats(stats2, "skill-thorough",
                 "/tmp/skillB", "dummy_skill-thorough", Duration.ofSeconds(80));
 
-        // Generate global summary
+        // Generate Benchmark report
         Path historyFile = tempDir.resolve("history.jsonl");
         ResultsTracker tracker = new ResultsTracker(historyFile);
 
         Map<String, List<MigrationResult>> bySkill = new LinkedHashMap<>();
         bySkill.put("skills/skill-fast", List.of(rA));
         bySkill.put("skills/skill-thorough", List.of(rB));
-        tracker.writeGlobalSummary(bySkill);
+        tracker.writeBenchmarkComparisonReport(bySkill);
 
-        String global = Files.readString(tempDir.resolve("global.summary.md"));
+        String benchmark = Files.readString(tempDir.resolve("benchmark-report.md"));
 
-        assertContains(global, "skills/skill-fast vs skills/skill-thorough");
+        assertContains(benchmark, "skills/skill-fast vs skills/skill-thorough");
 
         // Skill A row
-        assertContains(global, "| skills/skill-fast | 1 |");
-        assertContains(global, "45,924 (+/- 0)");
-        assertContains(global, "$0.15 (+/- $0.00)");
+        assertContains(benchmark, "| skills/skill-fast | 1 |");
+        assertContains(benchmark, "45,924 (+/- 0)");
+        assertContains(benchmark, "$0.15 (+/- $0.00)");
 
         // Skill B row
-        assertContains(global, "| skills/skill-thorough | 1 |");
-        assertContains(global, "91,652 (+/- 0)");
-        assertContains(global, "$0.30 (+/- $0.00)");
+        assertContains(benchmark, "| skills/skill-thorough | 1 |");
+        assertContains(benchmark, "91,652 (+/- 0)");
+        assertContains(benchmark, "$0.30 (+/- $0.00)");
 
         // Delta row
-        assertContains(global, "| **Delta** |");
+        assertContains(benchmark, "| **Delta** |");
         // Duration: (80-40)/40 = +100.0%
-        assertContains(global, "+100.0%");
+        assertContains(benchmark, "+100.0%");
     }
 
     // ─── Mean / Stddev math ───────────────────────────────────────────

--- a/tests/src/test/java/io/quarkus/migration/test/BenchmarkReportTest.java
+++ b/tests/src/test/java/io/quarkus/migration/test/BenchmarkReportTest.java
@@ -89,7 +89,7 @@ class BenchmarkReportTest {
 
     @Test
     @DisplayName("end-to-end: two fixture sessions produce correct benchmark-report.md with delta")
-    void EndToEndTestFromFixtures() throws IOException {
+    void endToEndTestFromFixtures() throws IOException {
         Path fixture1 = tempDir.resolve("session1.jsonl");
         Path fixture2 = tempDir.resolve("session2.jsonl");
         try (var in1 = getClass().getResourceAsStream("/sessions/dummy1_claude_session.jsonl");

--- a/tests/src/test/java/io/quarkus/migration/test/SkillRunReportTest.java
+++ b/tests/src/test/java/io/quarkus/migration/test/SkillRunReportTest.java
@@ -1,0 +1,155 @@
+package io.quarkus.migration.test;
+
+import io.quarkus.migration.MigrationResult;
+import io.quarkus.migration.ResultsTracker;
+import io.quarkus.migration.SkillReference;
+import io.quarkus.migration.runner.AgentRunner;
+import io.quarkus.migration.runner.ClaudeRunner;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates the data of the Skill report generated
+ */
+class SkillRunReportTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("writeSkillReportSingleRun with single run has zero stddev")
+    void writeSkillReportSingleRun() throws IOException {
+        Path historyFile = tempDir.resolve("history.jsonl");
+        ResultsTracker tracker = new ResultsTracker(historyFile);
+
+        MigrationResult r = buildResult("dummy", "claude-opus-4-6", "solo");
+        r.setDuration(Duration.ofSeconds(28));
+        r.setTotalTokens(75_241);
+        r.setTotalCost(0.195412);
+
+        tracker.writeSkillSummaryReport(List.of(r), "single-run");
+
+        String benchmark = Files.readString(tempDir.resolve("single-run-report.md"));
+
+        assertContains(benchmark, "0m 28s (+/- 0s)");
+        assertContains(benchmark, "$0.20 (+/- $0.00)");
+    }
+
+    @Test
+    @DisplayName("writeSkillReportFor2Runs computes correct averages and stddev for 2 runs")
+    void writeSkillReportFor2Runs() throws IOException {
+        Path historyFile = tempDir.resolve("history.jsonl");
+        ResultsTracker tracker = new ResultsTracker(historyFile);
+
+        MigrationResult r1 = buildResult("dummy", "claude-opus-4-6", "run1");
+        r1.setDuration(Duration.ofSeconds(60));
+        r1.setTotalTokens(70_000);
+        r1.setTotalCost(0.50);
+        r1.setInputTokens(800);
+        r1.setOutputTokens(500);
+        r1.setCacheRead(45_000);
+        r1.setCacheWrite(23_700);
+
+        MigrationResult r2 = buildResult("dummy", "claude-opus-4-6", "run2");
+        r2.setDuration(Duration.ofSeconds(80));
+        r2.setTotalTokens(80_000);
+        r2.setTotalCost(0.70);
+        r2.setInputTokens(1000);
+        r2.setOutputTokens(600);
+        r2.setCacheRead(55_000);
+        r2.setCacheWrite(23_400);
+
+        tracker.writeSkillSummaryReport(List.of(r1, r2), "two-runs");
+
+        String benchmark = Files.readString(tempDir.resolve("two-runs-report.md"));
+
+        // Avg duration = 70s => 1m 10s, stddev = 10s
+        assertContains(benchmark, "1m 10s (+/- 10s)");
+
+        // Avg cost = $0.60, stddev = $0.10
+        assertContains(benchmark, "$0.60 (+/- $0.10)");
+
+        // Avg total tokens = 75,000, stddev = 5,000
+        assertContains(benchmark, "75,000 (+/- 5,000)");
+    }
+
+    // ─── Mean / Stddev math ───────────────────────────────────────────
+    @Test
+    @DisplayName("mean and stddev formulas: population stddev (not sample)")
+    void meanAndStddev() {
+        double[] values = {60.0, 80.0};
+        double mean = 0;
+        for (double v : values) mean += v;
+        mean /= values.length;
+
+        double sumSq = 0;
+        for (double v : values) sumSq += (v - mean) * (v - mean);
+        double stddev = Math.sqrt(sumSq / values.length);
+
+        assertEquals(70.0, mean, 0.001);
+        assertEquals(10.0, stddev, 0.001);
+    }
+
+    @Test
+    @DisplayName("stddev of identical values is zero")
+    void stddevZero() {
+        double[] values = {42.0, 42.0, 42.0};
+        double mean = 42.0;
+        double sumSq = 0;
+        for (double v : values) sumSq += (v - mean) * (v - mean);
+        double stddev = Math.sqrt(sumSq / values.length);
+
+        assertEquals(0.0, stddev, 0.0001);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────
+
+    private MigrationResult buildResult(String project, String model, String runName) {
+        SkillReference skillRef = new SkillReference("test-skill", null, "/tmp/skill");
+        MigrationResult result = new MigrationResult("claude", project, model, "full", skillRef);
+        result.setRunName(runName);
+        result.setDuration(Duration.ofSeconds(28));
+        result.setPrompt("Say Hello.");
+        result.setTotalTokens(74_406);
+        result.setTotalCost(0.195412);
+        result.setInputTokens(5);
+        result.setOutputTokens(494);
+        result.setCacheRead(48_661);
+        result.setCacheWrite(25_246);
+        result.setToolCalls(2);
+        return result;
+    }
+
+    private MigrationResult buildResultFromStats(AgentRunner.UsageStats stats,
+            String skillName, String skillPath, String runName, Duration duration) {
+        SkillReference ref = new SkillReference(skillName, null, skillPath);
+        MigrationResult r = new MigrationResult("claude", "dummy", "claude-opus-4-6", "full", ref);
+        r.setRunName(runName);
+        r.setDuration(duration);
+        r.setTotalTokens(stats.totalTokens());
+        r.setTotalCost(stats.totalCost());
+        r.setToolCalls(stats.toolCalls());
+        r.setInputTokens(stats.inputTokens());
+        r.setOutputTokens(stats.outputTokens());
+        r.setCacheRead(stats.cacheRead());
+        r.setCacheWrite(stats.cacheWrite());
+        return r;
+    }
+
+    private static void assertContains(String content, String expected) {
+        assertTrue(content.contains(expected),
+                "Expected to find:\n  " + expected + "\nin:\n" + content);
+    }
+}


### PR DESCRIPTION
## Description of the changes

- Rename Global Summary report to Benchmark report,
- Refactor the tests to define more user friendly method names,

## Testing

Here are different cases tested locally to verify

### 1 skill & 1 project

```shell
mvn clean test -Dai.prompt="Say Hello" -Dai.project=dummy -Dai.skill=../tests/skills/dummy -Dai.review=false
```
3 files created:
dummy_claude-opus-4-6.json.log
dummy_claude-opus-4-6.pretty.md
dummy_claude-opus-4-6.report.md // One summary report

### 1 skill & 1 project but 2 runs

```shell
mvn clean test -Dai.prompt="Say Hello" -Dai.project=dummy -Dai.skill=../tests/skills/dummy -Druns=2 -Dai.review=false
```
7 files created:
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6-report.md // One report with table summary the results of the 2 runs
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6_run1.json.log
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6_run1.pretty.md
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6_run1.report.md
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6_run2.json.log
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6_run2.pretty.md
/Users/cmoullia/code/quarkus/fork-quarkus-skills/tests/target/runs/dummy_claude-opus-4-6_run2.report.md

### 2 skills & 1 project

```shell
mvn clean test -Dai.prompt="Say Hello" -Dai.project=dummy -Dai.skills=../tests/skills/dummy,../tests/skills/dummy1 -Dai.review=false
```
7 files created:
benchmark-report.md => include the comparison of the 2 skills with delta
dummy_dummy1_claude-opus-4-6.json.log
dummy_dummy1_claude-opus-4-6.pretty.md
dummy_dummy1_claude-opus-4-6.report.md
dummy_dummy_claude-opus-4-6.json.log
dummy_dummy_claude-opus-4-6.pretty.md
dummy_dummy_claude-opus-4-6.report.md
```

